### PR TITLE
Fixes #307 & #354

### DIFF
--- a/dist/assets/config.json
+++ b/dist/assets/config.json
@@ -7,7 +7,7 @@
     "errorsURL": "Errors",
     "loginURL": "authenticate",
     "managersURL": "Managers",
-    "regionURL": "Regions/",
+    "regionURL": "Regions",
     "regRegionURL": "RegressionRegions",
     "regTypeURL": "RegressionTypes",
     "rolesURL": "Roles",

--- a/src/app/gagestats/add-station/add-station.component.ts
+++ b/src/app/gagestats/add-station/add-station.component.ts
@@ -95,7 +95,7 @@ export class AddStationModal implements OnInit {
     delete station.longitude;
     station = {...station, 'location': location};
 
-    this._settingsService.postEntityGageStats(station, this.configSettings.stationsURL)
+    this._settingsService.postEntity(station,this.configSettings.gageStatsBaseURL + this.configSettings.stationsURL)
       .subscribe((response:any) =>{
         if(!response.headers){
           this._toasterService.pop('info', 'Info', 'Station Added');

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -120,7 +120,8 @@
 							</td>
 							<td>
 								<span *ngIf="!c.isEditing">{{c.citationID}}</span>
-								<span *ngIf="c.isEditing"><input type="number" [(ngModel)]="c.citationID" size="2" class="input-100"></span>
+								<span *ngIf="c.isEditing">{{c.citationID}}</span>
+								<button *ngIf="c.isEditing" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
                             </td>
                             <td>
 								<span *ngIf="!c.isEditing">{{c.comments}}</span>

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -2,7 +2,7 @@
 	<div>
 		<div class="modal-header">
 			<div class="title">GagePage</div>  
-			<button class="icon-button" (click)="d('closed'); editGage=false; cancelEditGageInfo()"><i class="far fa-times"></i></button>                    
+			<!-- <button class="icon-button" (click)="d('closed'); editGage=false; cancelEditGageInfo()"><i class="far fa-times"></i></button>  -->
 		</div>
 	</div>
 
@@ -159,9 +159,10 @@
 								</span>
 							</td>
 							<td>
-								<span *ngIf="!c.isEditing">{{c.citationID}}</span>
-								<span *ngIf="c.isEditing">{{c.citationID}}</span>
-								<button *ngIf="c.isEditing" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
+								<span *ngIf="!newChar.isEditing">{{newChar.citationID}}</span>
+								<span *ngIf="selectedCitation">{{selectedCitation.id}}</span>
+								<button *ngIf="newChar.isEditing && !selectedCitation" type="button" class="button small blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
+								<button *ngIf="newChar.isEditing && selectedCitation" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
                             </td>
                             <td>
 								<span *ngIf="!newChar.isEditing">{{newChar.comments}}</span>
@@ -207,10 +208,9 @@
 								</span>
 							</td>
 							<td>
-								<span *ngIf="!newChar.isEditing">{{newChar.citationID}}</span>
-								<span *ngIf="selectedCitation">{{selectedCitation.id}}</span>
-								<button *ngIf="newChar.isEditing && !selectedCitation" type="button" class="button small blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
-								<button *ngIf="newChar.isEditing && selectedCitation" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
+								<span *ngIf="!c.isEditing">{{c.citationID}}</span>
+								<span *ngIf="c.isEditing">{{c.citationID}}</span>
+								<button *ngIf="c.isEditing" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
                             </td>
                             <td>
 								<span *ngIf="!c.isEditing">{{c.comments}}</span>
@@ -292,8 +292,10 @@
 										</span>
                                     </td> 
                                     <td>
-									    <span *ngIf="!newStat.isEditing">{{newStat.citationID}}</span>
-                                        <span *ngIf="newStat.isEditing"><input type="number" [(ngModel)]="newStat.citationID" size="2"></span>
+										<span *ngIf="!newStat.isEditing">{{newStat.citationID}}</span>
+										<span *ngIf="selectedCitation">{{selectedCitation.id}}</span>
+										<button *ngIf="newStat.isEditing && !selectedCitation" type="button" class="button small blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
+										<button *ngIf="newStat.isEditing && selectedCitation" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>                            
 									</td>
 									<td>
 									    <span *ngIf="!newStat.isEditing">{{getStatGroup(newStat.statisticGroupTypeID)}}</span>
@@ -372,7 +374,8 @@
 											</td>
 											<td>
 												<span *ngIf="!s.isEditing">{{s.citationID}}</span>
-												<span *ngIf="s.isEditing"><input type="number" [(ngModel)]="s.citationID" size="2" class="input-100"></span>
+												<span *ngIf="s.isEditing">{{s.citationID}}</span>
+												<button *ngIf="s.isEditing" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
 											</td>
 											<td *ngIf="editGage">
 												<span *ngIf="!s.isEditing">{{getStatGroup(s.statisticGroupTypeID)}}</span>

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -161,8 +161,8 @@
 							<td>
 								<span *ngIf="!newChar.isEditing">{{newChar.citationID}}</span>
 								<span *ngIf="selectedCitation">{{selectedCitation.id}}</span>
-								<button *ngIf="newChar.isEditing && !selectedCitation" type="button" class="button blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
-								<button *ngIf="newChar.isEditing && selectedCitation" type="button" title="Change Citation" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
+								<button *ngIf="newChar.isEditing && !selectedCitation" type="button" class="button blue mright-xs" (click)="showManageCitationsModal(newChar)"><i class="far fa-plus"></i></button>
+								<button *ngIf="newChar.isEditing && selectedCitation" type="button" title="Change Citation" (click)="showManageCitationsModal(newChar)"><i class="far fa-pencil"></i></button>
                             </td>
                             <td>
 								<span *ngIf="!newChar.isEditing">{{newChar.comments}}</span>
@@ -210,7 +210,7 @@
 							<td>
 								<span *ngIf="!c.isEditing">{{c.citationID}}</span>
 								<span *ngIf="c.isEditing">{{c.citationID}}</span>
-								<button *ngIf="c.isEditing" type="button" title="Change Citation" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
+								<button *ngIf="c.isEditing" type="button" title="Change Citation" (click)="showManageCitationsModal(c)"><i class="far fa-pencil"></i></button>
                             </td>
                             <td>
 								<span *ngIf="!c.isEditing">{{c.comments}}</span>
@@ -294,8 +294,8 @@
                                     <td>
 										<span *ngIf="!newStat.isEditing">{{newStat.citationID}}</span>
 										<span *ngIf="selectedCitation">{{selectedCitation.id}}</span>
-										<button *ngIf="newStat.isEditing && !selectedCitation" type="button" class="button blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
-										<button *ngIf="newStat.isEditing && selectedCitation" type="button" title="Change Citation" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>                            
+										<button *ngIf="newStat.isEditing && !selectedCitation" type="button" class="button blue mright-xs" (click)="showManageCitationsModal(newStat)"><i class="far fa-plus"></i></button>
+										<button *ngIf="newStat.isEditing && selectedCitation" type="button" title="Change Citation" (click)="showManageCitationsModal(newStat)"><i class="far fa-pencil"></i></button>                            
 									</td>
 									<td>
 									    <span *ngIf="!newStat.isEditing">{{getStatGroup(newStat.statisticGroupTypeID)}}</span>
@@ -375,7 +375,7 @@
 											<td>
 												<span *ngIf="!s.isEditing">{{s.citationID}}</span>
 												<span *ngIf="s.isEditing">{{s.citationID}}</span>
-												<button *ngIf="s.isEditing" type="button" title="Change Citation" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
+												<button *ngIf="s.isEditing" type="button" title="Change Citation" (click)="showManageCitationsModal(s)"><i class="far fa-pencil"></i></button>
 											</td>
 											<td *ngIf="editGage">
 												<span *ngIf="!s.isEditing">{{getStatGroup(s.statisticGroupTypeID)}}</span>

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -104,13 +104,13 @@
 			</div>
 		</div>
 		<!--Physical Characteristics-->
-		<div>
+		<div *ngIf="gage.characteristics.length > 0 || editGage">
 			<div class="table-title">Physical Characteristics
 				<div class="stat-filters">
 					<div><button *ngIf="loggedInRole && editGage" type="button" class="button small blue mright-xs"  (click)="addPhysicalCharacteristic(cIndex)">Add Physical Characteristic</button></div>
 				</div>
 			</div>
-			<div *ngIf="gage.characteristics.length > 0 || editGage">
+			<div >
 				<table style="border:solid 1px gray" class="custom-table"> 
 					<thead>
 						<tr>
@@ -222,7 +222,7 @@
 			</div>
 		</div>
 		<!--Streamflow Statistics Table-->
-		<div>
+		<div *ngIf="gage.statistics.length > 0  || editGage">
 			<div class="table-title">Streamflow Statistics
 				<div class="stat-filters">
 					<div><label>Filter by Statistic Group: </label></div>
@@ -443,6 +443,6 @@
 
 	<!-- Footer / Buttons -->
 	<div class="modal-body-footer">
-		<button type="button" (click)="d('closed'); editGage=false; cancelEditGageInfo()" [disabled]="editGage" class="button black">Close</button>
+		<button type="button" (click)="d('closed'); editGage=false" [disabled]="editGage" class="button black">Close</button>
 	</div>
 </ng-template>

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -165,6 +165,7 @@
 							<td>
 								<span *ngIf="!newChar.isEditing">{{newChar.citationID}}</span>
 								<span *ngIf="newChar.isEditing"><input type="number" [(ngModel)]="newChar.citationID" size="2"></span>
+								<button *ngIf="newChar.isEditing" type="button" class="button small blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
                             </td>
                             <td>
 								<span *ngIf="!newChar.isEditing">{{newChar.comments}}</span>

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -164,8 +164,9 @@
 							</td>
 							<td>
 								<span *ngIf="!newChar.isEditing">{{newChar.citationID}}</span>
-								<span *ngIf="newChar.isEditing"><input type="number" [(ngModel)]="newChar.citationID" size="2"></span>
-								<button *ngIf="newChar.isEditing" type="button" class="button small blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
+								<span *ngIf="selectedCitation">{{selectedCitation.id}}</span>
+								<button *ngIf="newChar.isEditing && !selectedCitation" type="button" class="button small blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
+								<button *ngIf="newChar.isEditing && selectedCitation" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
                             </td>
                             <td>
 								<span *ngIf="!newChar.isEditing">{{newChar.comments}}</span>

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -161,8 +161,8 @@
 							<td>
 								<span *ngIf="!newChar.isEditing">{{newChar.citationID}}</span>
 								<span *ngIf="selectedCitation">{{selectedCitation.id}}</span>
-								<button *ngIf="newChar.isEditing && !selectedCitation" type="button" class="button small blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
-								<button *ngIf="newChar.isEditing && selectedCitation" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
+								<button *ngIf="newChar.isEditing && !selectedCitation" type="button" class="button blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
+								<button *ngIf="newChar.isEditing && selectedCitation" type="button" title="Change Citation" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
                             </td>
                             <td>
 								<span *ngIf="!newChar.isEditing">{{newChar.comments}}</span>
@@ -210,7 +210,7 @@
 							<td>
 								<span *ngIf="!c.isEditing">{{c.citationID}}</span>
 								<span *ngIf="c.isEditing">{{c.citationID}}</span>
-								<button *ngIf="c.isEditing" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
+								<button *ngIf="c.isEditing" type="button" title="Change Citation" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
                             </td>
                             <td>
 								<span *ngIf="!c.isEditing">{{c.comments}}</span>
@@ -294,8 +294,8 @@
                                     <td>
 										<span *ngIf="!newStat.isEditing">{{newStat.citationID}}</span>
 										<span *ngIf="selectedCitation">{{selectedCitation.id}}</span>
-										<button *ngIf="newStat.isEditing && !selectedCitation" type="button" class="button small blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
-										<button *ngIf="newStat.isEditing && selectedCitation" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>                            
+										<button *ngIf="newStat.isEditing && !selectedCitation" type="button" class="button blue mright-xs" (click)="showManageCitationsModal()">Add Citation</button>
+										<button *ngIf="newStat.isEditing && selectedCitation" type="button" title="Change Citation" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>                            
 									</td>
 									<td>
 									    <span *ngIf="!newStat.isEditing">{{getStatGroup(newStat.statisticGroupTypeID)}}</span>
@@ -375,7 +375,7 @@
 											<td>
 												<span *ngIf="!s.isEditing">{{s.citationID}}</span>
 												<span *ngIf="s.isEditing">{{s.citationID}}</span>
-												<button *ngIf="s.isEditing" type="button" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
+												<button *ngIf="s.isEditing" type="button" title="Change Citation" (click)="showManageCitationsModal()"><i class="far fa-pencil"></i></button>
 											</td>
 											<td *ngIf="editGage">
 												<span *ngIf="!s.isEditing">{{getStatGroup(s.statisticGroupTypeID)}}</span>

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -11,6 +11,7 @@ import { CharacteristicResponse } from 'app/shared/interfaces/characteristicresp
 import { ToasterService } from 'angular2-toaster/angular2-toaster';
 import { GageStatistic } from 'app/shared/interfaces/gagestatistic';
 import { StatisticResponse } from 'app/shared/interfaces/statisticresponse';
+import { ManageCitation } from 'app/shared/interfaces/managecitations';
 
 @Component({
   selector: 'gagePageModal',
@@ -19,6 +20,7 @@ import { StatisticResponse } from 'app/shared/interfaces/statisticresponse';
 })
 export class GagepageComponent implements OnInit, OnDestroy {
   @ViewChild('gagePage', {static: true}) public gagePageModal; // : ModalDirective;  //modal for validator
+  @ViewChild('CitationForm', { static: true }) citationForm;
   private modalSubscript;
   private configSettings: Config;
   private modalElement: any;
@@ -37,6 +39,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
   public variables;
   public regressionTypes;
   public statisticGroups;
+  public addCitation: boolean;
 
   constructor(
     private _nssService: NSSService, 
@@ -269,6 +272,19 @@ export class GagepageComponent implements OnInit, OnDestroy {
   getStatGroup(id) {
       return this.statisticGroups.find(sg => sg.id == id).name;
   }
+
+///////////////////////Citation Modal Section/////////////////////
+
+  public showManageCitationsModal() {
+    const addManageCitationForm: ManageCitation = {
+        show: true,
+        addCitation: true
+    }
+    this._nssService.setManageCitationsModal(addManageCitationForm);
+}
+
+
+///////////////////////////////////////////////////////////////////////
 
   compareObjects(Obj1, Obj2) {
     // used to make sure the existing options are showing in selects

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -40,6 +40,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
   public regressionTypes;
   public statisticGroups;
   public addCitation: boolean;
+  public selectedCitation;
 
   constructor(
     private _nssService: NSSService, 
@@ -58,12 +59,19 @@ export class GagepageComponent implements OnInit, OnDestroy {
           this.code = result.gageCode;
           this._nssService.getGagePageInfo(this.code).subscribe(res => {
             this.gage = res;
+            this._nssService.setSelectedRegion(this.gage.region);
             this.getCitations();
             this.showGagePageForm();
           });
         }
     });
     this.modalElement = this.gagePageModal;
+
+    this._nssService.selectedCitation.subscribe(c => {
+      this.selectedCitation = c;
+      this.newChar.citationID = this.selectedCitation.id;
+      console.log(this.newChar)
+    }); 
 
     // get all unit types 
     this._nssService.getUnitTypes().subscribe(res => {
@@ -163,7 +171,6 @@ export class GagepageComponent implements OnInit, OnDestroy {
     }
     
   this.newChar.isEditing = true;
-  //this.itemBeingEdited = this.newChar;
   } 
     
   public deletePhysicalCharacteristic(deleteID: number) {
@@ -174,7 +181,6 @@ export class GagepageComponent implements OnInit, OnDestroy {
           this._settingsservice.deleteEntityGageStats(deleteID, this.configSettings.characteristicsURL).subscribe(
             (res) => {
               this.refreshgagepage();
-              //this.gage.characteristics.splice(index, 1)
               this._settingsservice.outputWimMessages(res);
             }
           )
@@ -278,10 +284,11 @@ export class GagepageComponent implements OnInit, OnDestroy {
   public showManageCitationsModal() {
     const addManageCitationForm: ManageCitation = {
         show: true,
-        addCitation: true
-    }
+        addCitation: true,
+        inGagePage: true
+    } 
     this._nssService.setManageCitationsModal(addManageCitationForm);
-}
+  }
 
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -115,11 +115,11 @@ export class GagepageComponent implements OnInit, OnDestroy {
       this.variables = res;
     });
     // get all regression types
-    this._settingsservice.getEntities(this.configSettings.regTypeURL).subscribe(res => {
+    this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regTypeURL).subscribe(res => {
       this.regressionTypes = res;
     });
     // get all stat groups 
-    this._settingsservice.getEntities(this.configSettings.statisticGrpURL).subscribe(res => {
+    this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.statisticGrpURL).subscribe(res => {
       this.statisticGroups = res;
     });
     // get all agencys
@@ -212,7 +212,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
   public deleteGageStats(id){
     const check = confirm('Are you sure you want to delete this Gage?');
     if (check) {
-      this._settingsservice.deleteEntityGageStats(id, this.configSettings.stationsURL).subscribe(result => {
+      this._settingsservice.deleteEntity(id, this.configSettings.gageStatsBaseURL + this.configSettings.stationsURL).subscribe(result => {
           if (result.headers) { 
             this._nssService.outputWimMessages(result); 
             this.modalRef.close();    
@@ -229,7 +229,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
   public saveGageInfo(gage){
     const newItem = JSON.parse(JSON.stringify(gage)); 
     ['agency', 'stationType'].forEach(e => delete newItem[e]);  
-      this._settingsservice.putEntityGageStats(newItem.id, newItem, this.configSettings.stationsURL).subscribe(
+      this._settingsservice.putEntity(newItem.id, newItem, this.configSettings.gageStatsBaseURL + this.configSettings.stationsURL).subscribe(
         (res) => {
           this.editGageInfo = false;
           this.code = res.body['code']; // update code in case user changed it
@@ -287,11 +287,6 @@ export class GagepageComponent implements OnInit, OnDestroy {
     delete(this.itemBeingEdited);
   }
 
-  public submitGage() {
-    const url = '';
-    this._settingsservice.putEntityGageStats('', this.configSettings.stationsURL, url).subscribe();
-  }
-
 ///////////////////////Characteristic Section////////////////
   
   public addPhysicalCharacteristic() {
@@ -315,7 +310,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       if (check) {
         const index = this.gage.characteristics.findIndex(item => item.id === deleteID);
         if (deleteID) {    // If characteristic has an ID number (if it comes from the service)
-          this._settingsservice.deleteEntityGageStats(deleteID, this.configSettings.characteristicsURL).subscribe(
+          this._settingsservice.deleteEntity(deleteID, this.configSettings.gageStatsBaseURL + this.configSettings.characteristicsURL).subscribe(
             (res) => {
               this.refreshgagepage();
               this._settingsservice.outputWimMessages(res);
@@ -328,7 +323,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
     if (item.id) {  // If item has an id, then it is already in NSS DB
       const newItem = JSON.parse(JSON.stringify(item));  // Copy the edited char
       delete newItem.unitType, delete newItem.variableType, delete newItem.citation;  // Delete uneeded objects from the copy
-      this._settingsservice.putEntityGageStats(newItem.id, newItem, this.configSettings.characteristicsURL).subscribe(
+      this._settingsservice.putEntity(newItem.id, newItem, this.configSettings.gageStatsBaseURL + this.configSettings.characteristicsURL).subscribe(
         (res) => { 
           item.isEditing = false;
           delete(this.itemBeingEdited);
@@ -338,7 +333,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       )
     }; if (!item.id) {  // If an item doesn't have an ID, then it needs to be added to NSS
       delete item.isEditing;
-      this._settingsservice.postEntityGageStats(item, this.configSettings.characteristicsURL).subscribe(
+      this._settingsservice.postEntity(item,this.configSettings.gageStatsBaseURL + this.configSettings.characteristicsURL).subscribe(
         (res: CharacteristicResponse) => { 
           item.isEditing = false; 
           delete(this.newChar);
@@ -380,7 +375,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       }
       ['regressionType', 'citation',
       'unitType', 'isEditing', 'statisticGroupType'].forEach(e => delete newItem[e]);  // Delete unneeded items
-      this._settingsservice.putEntityGageStats(newItem.id, newItem, this.configSettings.statisticsURL).subscribe(
+      this._settingsservice.putEntity(newItem.id, newItem, this.configSettings.gageStatsBaseURL + this.configSettings.statisticsURL).subscribe(
         (res) => {
           item.isEditing = false;
           delete(this.itemBeingEdited);
@@ -392,7 +387,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       if ( !item.predictionInterval.variance && !item.predictionInterval.lowerConfidenceInterval && !item.predictionInterval.upperConfidenceInterval ) {
         delete(item.predictionInterval)
       }
-      this._settingsservice.postEntityGageStats(item, this.configSettings.statisticsURL).subscribe(
+      this._settingsservice.postEntity(item,this.configSettings.gageStatsBaseURL + this.configSettings.statisticsURL).subscribe(
         (res: StatisticResponse) => {
           item.isEditing = false;
           delete(this.newStat);  // Delete newStat from table
@@ -409,7 +404,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       if (check) {
         const index = this.gage.statistics.findIndex(item => item.id === deleteID);
         if (deleteID) {    // If statistic has an ID number (if it comes from the service)
-          this._settingsservice.deleteEntityGageStats(deleteID, this.configSettings.statisticsURL).subscribe(
+          this._settingsservice.deleteEntity(deleteID, this.configSettings.gageStatsBaseURL + this.configSettings.statisticsURL).subscribe(
             (res) => {
               delete(this.itemBeingEdited);
               this.refreshgagepage();

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -38,6 +38,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
   public editGageInfo: boolean = false;
   public units;
   public tempItem;
+  public tempGage;
   public itemBeingEdited;
   public editId;
   public newChar: GageCharacteristic;
@@ -240,12 +241,13 @@ export class GagepageComponent implements OnInit, OnDestroy {
   }
 
   public editGageInformation(item) {
+    this.limitRowEdits();
     this.editGageInfo = true;
-    this.tempItem = JSON.parse(JSON.stringify(item));
+    this.tempGage = JSON.parse(JSON.stringify(item));
   }
 
   public cancelEditGageInfo() {
-    this.gage = this.tempItem;
+    this.gage = this.tempGage;
     this.editGageInfo = false;
   }
 
@@ -265,13 +267,14 @@ export class GagepageComponent implements OnInit, OnDestroy {
   } 
 
   public editRowClicked(item, index) {
+    this.cancelEditGageInfo();
     this.limitRowEdits();
     if (!item.predictionInterval) { //If the stat doesn't have prediction intervals, create empty ones for display
       item.predictionInterval = {variance: null, lowerConfidenceInterval: null, upperConfidenceInterval: null};
     }
     this.tempItem = JSON.parse(JSON.stringify(item));
     this.itemBeingEdited = item;
-    this.editId = index
+    this.editId = index;
     item.isEditing = true;
     delete(this.selectedCitation);
   }
@@ -294,6 +297,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
 ///////////////////////Characteristic Section////////////////
   
   public addPhysicalCharacteristic() {
+    this.cancelEditGageInfo();
     this.limitRowEdits();
     // Create new characteristic
     this.newChar = {
@@ -352,6 +356,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
 ///////////////////////Statistic Section/////////////////////
   
   public addStreamflowStatistic() {
+    this.cancelEditGageInfo();
     this.limitRowEdits();
     this.newStat = {
       stationID: this.gage.id,

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -69,8 +69,17 @@ export class GagepageComponent implements OnInit, OnDestroy {
 
     this._nssService.selectedCitation.subscribe(c => {
       this.selectedCitation = c;
-      this.newChar.citationID = this.selectedCitation.id;
-      console.log(this.newChar)
+      if (this.newChar){  //If a new characteristic is created
+        this.newChar.citationID = this.selectedCitation.id; //Set the citationID to the id of the selected citation from the citation modal
+        console.log(this.newChar)
+      } if (!this.itemBeingEdited.yearsofRecord) {  //If a characteristic is being edited
+          this.itemBeingEdited.citationID = this.selectedCitation.id;
+          console.log(this.itemBeingEdited)
+      } if (this.newStat) { //If a new stat is created
+          this.newStat.citationID = this.selectedCitation.id
+      } if (this.itemBeingEdited.yearsofRecord) { //If itemBeingEdited is a stat
+          this.itemBeingEdited.citationID = this.selectedCitation.id
+      }
     }); 
 
     // get all unit types 
@@ -135,10 +144,18 @@ export class GagepageComponent implements OnInit, OnDestroy {
   } 
 
   public editRowClicked(item, index) {
-    this.tempItem = JSON.parse(JSON.stringify(item));
-    this.itemBeingEdited = item;
-    this.editId = index
-    item.isEditing = true;
+    if (this.itemBeingEdited) {  //If another item is being edited, cancel that first
+        this.cancelEditRowClicked(this.itemBeingEdited);
+        this.tempItem = JSON.parse(JSON.stringify(item));
+        this.itemBeingEdited = item;
+        this.editId = index
+        item.isEditing = true;
+    } else {
+      this.tempItem = JSON.parse(JSON.stringify(item));
+      this.itemBeingEdited = item;
+      this.editId = index
+      item.isEditing = true;
+    }
   }
 
   public cancelEditRowClicked(item) {
@@ -148,7 +165,6 @@ export class GagepageComponent implements OnInit, OnDestroy {
     else if (this.itemBeingEdited.statisticGroupTypeID) {  // is a statistic
       this.gage.statistics[this.editId] = this.tempItem;
     }
-    
     item.isEditing = false;
   }
 
@@ -199,6 +215,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
         }
       )
     }; if (!item.id) {  // If an item doesn't have an ID, then it needs to be added to NSS
+      delete item.isEditing;
       this._settingsservice.postEntityGageStats(item, this.configSettings.characteristicsURL).subscribe(
         (res: CharacteristicResponse) => { 
           item.isEditing = false; 

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -257,16 +257,6 @@ export class GagepageComponent implements OnInit, OnDestroy {
     this.editGage = false;
     this.editGageInfo = false;
     this.limitRowEdits();
-    //delete(this.tempItem);
-    // if (this.itemBeingEdited) {
-    //   this.itemBeingEdited.isEditing = false;
-    // }
-    // if (this.newChar) {
-    //   this.deletePhysicalCharacteristic(this.newChar.id);
-    // }
-    // if (this.newStat) {
-    //   this.deleteStatistic(this.newStat.id);
-    // }
     this.refreshgagepage();
     delete(this.tempGage);
     delete(this.tempItem);
@@ -299,7 +289,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
 
   public submitGage() {
     const url = '';
-    this._settingsservice.putEntityGageStats('', this.configSettings.stationsURL, url).subscribe()
+    this._settingsservice.putEntityGageStats('', this.configSettings.stationsURL, url).subscribe();
   }
 
 ///////////////////////Characteristic Section////////////////
@@ -316,7 +306,6 @@ export class GagepageComponent implements OnInit, OnDestroy {
       unitTypeID: null,
       citationID: null,
     }
-    console.log(this.newChar)
     this.newChar.isEditing = true;
     delete(this.selectedCitation);
   } 
@@ -342,7 +331,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       this._settingsservice.putEntityGageStats(newItem.id, newItem, this.configSettings.characteristicsURL).subscribe(
         (res) => { 
           item.isEditing = false;
-          delete(this.itemBeingEdited)
+          delete(this.itemBeingEdited);
           this.refreshgagepage();
           this._settingsservice.outputWimMessages(res);
         }
@@ -422,7 +411,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
         if (deleteID) {    // If statistic has an ID number (if it comes from the service)
           this._settingsservice.deleteEntityGageStats(deleteID, this.configSettings.statisticsURL).subscribe(
             (res) => {
-              delete(this.itemBeingEdited)
+              delete(this.itemBeingEdited);
               this.refreshgagepage();
               this._settingsservice.outputWimMessages(res);
             }
@@ -441,7 +430,6 @@ export class GagepageComponent implements OnInit, OnDestroy {
       this.getDisplayStatGroupID(this.gage);
       this.filterStatIds();
       this.getPredictionIntervals();
-      //this.limitRowEdits();
     });
   }
 
@@ -472,11 +460,9 @@ export class GagepageComponent implements OnInit, OnDestroy {
       this.cancelEditRowClicked(this.itemBeingEdited);
     }
     if (this.newChar) {
-      //this.deletePhysicalCharacteristic(this.newChar.id)
       delete(this.newChar);
     }
     if (this.newStat) {
-      //this.deleteStatistic(this.newStat.id)
       delete(this.newStat);
     }
   }

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -247,23 +247,30 @@ export class GagepageComponent implements OnInit, OnDestroy {
   }
 
   public cancelEditGageInfo() {
-    this.gage = this.tempGage;
-    this.editGageInfo = false;
+    if (this.editGageInfo) {
+      this.gage = this.tempGage;
+      this.editGageInfo = false;
+    }
   }
 
   public endEditGageStats() {
     this.editGage = false;
     this.editGageInfo = false;
-    if (this.itemBeingEdited) {
-      this.itemBeingEdited.isEditing = false;
-    }
-    if (this.newChar) {
-      this.deletePhysicalCharacteristic(this.newChar.id);
-    }
-    if (this.newStat) {
-      this.deleteStatistic(this.newStat.id);
-    }
+    this.limitRowEdits();
+    //delete(this.tempItem);
+    // if (this.itemBeingEdited) {
+    //   this.itemBeingEdited.isEditing = false;
+    // }
+    // if (this.newChar) {
+    //   this.deletePhysicalCharacteristic(this.newChar.id);
+    // }
+    // if (this.newStat) {
+    //   this.deleteStatistic(this.newStat.id);
+    // }
     this.refreshgagepage();
+    delete(this.tempGage);
+    delete(this.tempItem);
+    delete(this.itemBeingEdited);
   } 
 
   public editRowClicked(item, index) {
@@ -287,6 +294,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       this.gage.statistics[this.editId] = this.tempItem;
     }
     item.isEditing = false;
+    delete(this.itemBeingEdited);
   }
 
   public submitGage() {
@@ -308,6 +316,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       unitTypeID: null,
       citationID: null,
     }
+    console.log(this.newChar)
     this.newChar.isEditing = true;
     delete(this.selectedCitation);
   } 
@@ -432,6 +441,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
       this.getDisplayStatGroupID(this.gage);
       this.filterStatIds();
       this.getPredictionIntervals();
+      //this.limitRowEdits();
     });
   }
 
@@ -463,11 +473,11 @@ export class GagepageComponent implements OnInit, OnDestroy {
     }
     if (this.newChar) {
       //this.deletePhysicalCharacteristic(this.newChar.id)
-      delete(this.newChar)
+      delete(this.newChar);
     }
     if (this.newStat) {
       //this.deleteStatistic(this.newStat.id)
-      delete(this.newStat)
+      delete(this.newStat);
     }
   }
 

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -439,11 +439,12 @@ export class GagepageComponent implements OnInit, OnDestroy {
 
 ///////////////////////Citation Modal Section/////////////////////
 
-  public showManageCitationsModal() {
+  public showManageCitationsModal(c) {
     const addManageCitationForm: ManageCitation = {
         show: true,
         addCitation: true,
-        inGagePage: true
+        inGagePage: true,
+        selectCitation: c.citationID
     } 
     this._nssService.setManageCitationsModal(addManageCitationForm);
   }

--- a/src/app/gagestats/gagestats.component.html
+++ b/src/app/gagestats/gagestats.component.html
@@ -8,10 +8,11 @@
 
     <h4>{{timestamp | date:"MMMM d, y hh:mma"}}</h4>
 
-    <div class="hidden-print">
-        <button *ngIf="loggedInRole" type="button" class="button small blue mright-xs"  (click)="showAddStationModal()">Add Station</button>
-        <button *ngIf="loggedInRole" type="button" class="button small mright-xs" (click)="bulkUpload()">Bulk Upload</button>
-        <button *ngIf="loggedInRole" type="button" class="button small mright-xs" (click)="export()">Export</button>
+    <div *ngIf="loggedInRole" class="hidden-print">
+        <button  type="button" class="button small blue mright-xs"  (click)="showAddStationModal()">Add Station</button>
+        <button  type="button" class="button small mright-xs" (click)="bulkUpload()">Bulk Upload</button>
+        <button  type="button" class="button small mright-xs" (click)="export()">Export</button>
+        <button  type="button" class="button small" (click)="showManageCitationsModal()"><i class="far fa-asterisk"></i>Manage Citations</button>
     </div>
    
    <div class="hidden-print" >

--- a/src/app/gagestats/gagestats.component.ts
+++ b/src/app/gagestats/gagestats.component.ts
@@ -35,7 +35,7 @@ export class GagestatsComponent implements OnInit {
   public itemPerPage = [15,25,50,100]; 
   public perPage = 50;
   private configSettings: Config;
-  public config: ToasterConfig = new ToasterConfig({ timeout: 0 });
+  public config: ToasterConfig = new ToasterConfig({ timeout: 5000 });
 
 
   constructor(

--- a/src/app/gagestats/gagestats.component.ts
+++ b/src/app/gagestats/gagestats.component.ts
@@ -71,7 +71,8 @@ export class GagestatsComponent implements OnInit {
     this._nssService.stationTypes.subscribe((stationtypes: Array<StationType>) => {
       this.stationTypes = stationtypes;
     });
-    this._settingsservice.getEntitiesGageStats(this.configSettings.regionURL).subscribe((regions: Array<Region>) => {
+    // get all regions
+    this._nssService.regions.subscribe((regions: Array<Region>) => {
       this.regions = regions;
     });
     //subscribe to page number related information

--- a/src/app/gagestats/gagestats.component.ts
+++ b/src/app/gagestats/gagestats.component.ts
@@ -12,6 +12,7 @@ import { SettingsService } from 'app/settings/settings.service';
 import { ConfigService } from 'app/config.service';
 import { Config } from 'protractor';
 import { ToasterConfig } from 'angular2-toaster';
+import { ManageCitation } from 'app/shared/interfaces/managecitations';
 
 
 @Component({
@@ -132,6 +133,16 @@ export class GagestatsComponent implements OnInit {
       gageCode: s
   }
     this._nssService.setGagePageModal(gagePageForm);
+  }
+
+  public showManageCitationsModal() {
+    const addManageCitationForm: ManageCitation = {
+        show: true,
+        addCitation: true,
+        inGagePage: true,
+        inGageStats: true,
+    } 
+    this._nssService.setManageCitationsModal(addManageCitationForm);
   }
 
   //TODO: Bulk Upload Button

--- a/src/app/gagestats/gs-sidebar/gs-sidebar.component.ts
+++ b/src/app/gagestats/gs-sidebar/gs-sidebar.component.ts
@@ -51,16 +51,16 @@ export class GsSidebarComponent implements OnInit {
     this._nssService.agencies.subscribe((ag: Array<Agency>) => {
       this.agencies = ag;
     });
-    this._settingsservice.getEntitiesGageStats(this.configSettings.regionURL).subscribe((regions: Array<Region>) => {
+    this._settingsservice.getEntities(this.configSettings.gageStatsBaseURL + this.configSettings.regionURL).subscribe((regions: Array<Region>) => {
       this.regions = regions;
     });
-    this._settingsservice.getEntitiesGageStats(this.configSettings.statisticGrpURL).subscribe((sg: Array<Statisticgroup>) => {
+    this._settingsservice.getEntities(this.configSettings.gageStatsBaseURL + this.configSettings.statisticGrpURL).subscribe((sg: Array<Statisticgroup>) => {
       this.statisticGroups = sg;
     });
-    this._settingsservice.getEntitiesGageStats(this.configSettings.variablesURL).subscribe((vt: Array<Variabletype>) => {
+    this._settingsservice.getEntities(this.configSettings.gageStatsBaseURL + this.configSettings.variablesURL).subscribe((vt: Array<Variabletype>) => {
       this.variableTypes = vt;
     });
-    this._settingsservice.getEntitiesGageStats(this.configSettings.regTypeURL).subscribe((rt: Array<Regressiontype>) => {
+    this._settingsservice.getEntities(this.configSettings.gageStatsBaseURL + this.configSettings.regTypeURL).subscribe((rt: Array<Regressiontype>) => {
       this.regressionTypes = rt;
     });
 

--- a/src/app/mainview/mainview.component.ts
+++ b/src/app/mainview/mainview.component.ts
@@ -609,22 +609,22 @@ export class MainviewComponent implements OnInit {
             }
         });
         // get all errors (use for options in edit/add scenario selects)
-        this._settingsService.getEntities(this.configSettings.errorsURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.errorsURL).subscribe(res => {
             this.errors = res;
         });
         // get all regression types (use for options in edit/add scenario selects)
-        this._settingsService.getEntities(this.configSettings.regTypeURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.regTypeURL).subscribe(res => {
             this.regTypes = res;
         });
         this._nssService.regions.subscribe((regions: Array<Region>) => {
             this.regions = regions;
         });
         // get all status types (use for options in edit/add scenario selects)
-        this._settingsService.getEntities(this.configSettings.statusURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.statusURL).subscribe(res => {
             this.status = res;
         });
         // get all method types
-        this._settingsService.getEntities(this.configSettings.methodURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.methodURL).subscribe(res => {
             this.methods = res;
         });
     } // end ngOnInit()
@@ -1282,7 +1282,7 @@ export class MainviewComponent implements OnInit {
         if (check) {
             this.saveFilters();
             const sParams = '?statisticgroupID=' + sgID + '&regressionregionID=' + rrID + '&regressiontypeID=' + rID;
-            this._settingsService.deleteEntity('', this.configSettings.scenariosURL, sParams).subscribe(result => {
+            this._settingsService.deleteEntity('', this.configSettings.nssBaseURL + this.configSettings.scenariosURL, sParams).subscribe(result => {
                 this.requeryFilters();
                 if (result.headers) { this._nssService.outputWimMessages(result); }
             }, error => {
@@ -1297,7 +1297,7 @@ export class MainviewComponent implements OnInit {
         const check = confirm('Are you sure you want to delete this Regression Region?');
         if (check) {
             this.saveFilters();
-            this._settingsService.deleteEntity(rrID, this.configSettings.regRegionURL).subscribe(result => {
+            this._settingsService.deleteEntity(rrID, this.configSettings.nssBaseURL + this.configSettings.regRegionURL).subscribe(result => {
                 this.requeryFilters();
                 if (result.headers) { this._nssService.outputWimMessages(result); }
             }, error => {
@@ -1341,7 +1341,7 @@ export class MainviewComponent implements OnInit {
             const idx = this.regressionRegions.findIndex(r => r.id === rr.id);
             const regReg = this.regressionRegions[idx];
             regReg.citationID = null;
-            this._settingsService.putEntity(rr.id, regReg, this.configSettings.regRegionURL)
+            this._settingsService.putEntity(rr.id, regReg, this.configSettings.nssBaseURL + this.configSettings.regRegionURL)
                 .subscribe((response) => {
                     this.requeryFilters();
                     this._nssService.outputWimMessages(response);
@@ -1460,7 +1460,7 @@ export class MainviewComponent implements OnInit {
 
     public getRegRegions() {
         // get list of region's regression regions, remove if we take out the citations IDs
-        this._settingsService.getEntities(this.configSettings.regionURL + this.selectedRegion.id + '/' + this.configSettings.regRegionURL)
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + this.selectedRegion.id + '/' + this.configSettings.regRegionURL)
             .subscribe((res) => {
                 if (res.length > 1) {
                     res.sort((a, b) => a.name.localeCompare(b.name));
@@ -1479,7 +1479,7 @@ export class MainviewComponent implements OnInit {
     }
 
     public getCitations() {
-        this._settingsService.getEntities(this.configSettings.citationURL)
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.citationURL)
             .subscribe(res => {
                 this.citations = res;
             });
@@ -1517,7 +1517,7 @@ export class MainviewComponent implements OnInit {
     submitScenario() {
         // put edited scenario
         this.saveFilters();
-        this._settingsService.putEntity('', this.editScen, this.configSettings.scenariosURL)
+        this._settingsService.putEntity('', this.editScen, this.configSettings.nssBaseURL +  this.configSettings.scenariosURL)
             .subscribe((response) => {
                 this.requeryFilters();
                 this._nssService.outputWimMessages(response);
@@ -1608,7 +1608,7 @@ export class MainviewComponent implements OnInit {
     putLowFlow() {
         console.log(this.editScen);
         console.log(JSON.stringify(this.editScen));
-        this._settingsService.putEntity('', this.editScen, this.configSettings.scenariosURL + '?existingstatisticgroup=2')
+        this._settingsService.putEntity('', this.editScen, this.configSettings.nssBaseURL + this.configSettings.scenariosURL + '?existingstatisticgroup=2')
         .subscribe(scen => {
             console.log(scen);
             alert('success');
@@ -1626,7 +1626,7 @@ export class MainviewComponent implements OnInit {
         Object.keys(currentRR).forEach(key => {
             if (!this.editScenarioForm.value[key]) { this.editScenarioForm.value[key] = currentRR[key]; }
         });
-        this._settingsService.putEntity(rr.id, this.editScenarioForm.value, this.configSettings.regRegionURL).subscribe(res => {
+        this._settingsService.putEntity(rr.id, this.editScenarioForm.value, this.configSettings.nssBaseURL + this.configSettings.regRegionURL).subscribe(res => {
             this.CancelEditRowClicked();
             this.requeryFilters();
             if (!res.headers) {
@@ -1649,7 +1649,7 @@ export class MainviewComponent implements OnInit {
     public createNewCitation(rr) {
         // add new citation
         this.saveFilters();
-        this._settingsService.postEntity(this.newCitForm.value, this.configSettings.regRegionURL + '/' + rr.id + '/' +
+        this._settingsService.postEntity(this.newCitForm.value, this.configSettings.nssBaseURL + this.configSettings.regRegionURL + '/' + rr.id + '/' +
             this.configSettings.citationURL)
             .subscribe((res: any) => {
                 this.newCitForm.reset();

--- a/src/app/mainview/mainview.component.ts
+++ b/src/app/mainview/mainview.component.ts
@@ -1327,7 +1327,8 @@ export class MainviewComponent implements OnInit {
     public showManageCitationsModal() {
         const addManageCitationForm: ManageCitation = {
             show: true,
-            addCitation: true
+            addCitation: true,
+            inGagePage: false
         }
         this._nssService.setManageCitationsModal(addManageCitationForm);
     }

--- a/src/app/settings/categories/agencies/agencies.component.ts
+++ b/src/app/settings/categories/agencies/agencies.component.ts
@@ -70,7 +70,7 @@ export class AgenciesComponent implements OnInit, OnDestroy {
         }
 
     ngOnInit() {
-        this._settingsservice.getEntitiesGageStats(this.configSettings.agenciesURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.gageStatsBaseURL + this.configSettings.agenciesURL).subscribe(res => {
             this.agencies = <Array<any>>res;
         });
 
@@ -119,7 +119,7 @@ export class AgenciesComponent implements OnInit, OnDestroy {
 
     private createNewAgency() {
         const newItem = this.newAgencyForm.value;
-        this._settingsservice.postEntityGageStats(newItem, this.configSettings.agenciesURL)
+        this._settingsservice.postEntity(newItem, this.configSettings.gageStatsBaseURL + this.configSettings.agenciesURL)
             .subscribe((response: Agency) => {
                 response.isEditing = false;
                 this.agencies.push(response);
@@ -157,7 +157,7 @@ export class AgenciesComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Agency', 'Name and Code are required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntityGageStats(u.id, u, this.configSettings.agenciesURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.gageStatsBaseURL + this.configSettings.agenciesURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.agencies[i] = u;
@@ -180,7 +180,7 @@ export class AgenciesComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.agencies.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntityGageStats(deleteID, this.configSettings.agenciesURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.gageStatsBaseURL + this.configSettings.agenciesURL)
                 .subscribe(result => {
                     this.agencies.splice(index, 1);
                     this._settingsservice.setAgencies(this.agencies); // update service

--- a/src/app/settings/categories/errors/errors.component.ts
+++ b/src/app/settings/categories/errors/errors.component.ts
@@ -56,7 +56,7 @@ export class ErrorsComponent implements OnInit, OnDestroy {
         }
 
     ngOnInit() {
-        this._settingsservice.getEntities(this.configSettings.errorsURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.errorsURL).subscribe(res => {
             this.errors = res;
         });
 
@@ -98,7 +98,7 @@ export class ErrorsComponent implements OnInit, OnDestroy {
 
     private createNewError() {
         const newItem = this.newErrForm.value;
-        this._settingsservice.postEntity(newItem, this.configSettings.errorsURL)
+        this._settingsservice.postEntity(newItem, this.configSettings.nssBaseURL + this.configSettings.errorsURL)
             .subscribe((response: Error) => {
                 response.isEditing = false;
                 this.errors.push(response);
@@ -136,7 +136,7 @@ export class ErrorsComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Error', 'Name and Code are required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntity(u.id, u, this.configSettings.errorsURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.nssBaseURL + this.configSettings.errorsURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.errors[i] = u;
@@ -159,7 +159,7 @@ export class ErrorsComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.errors.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntity(deleteID, this.configSettings.errorsURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.nssBaseURL + this.configSettings.errorsURL)
                 .subscribe(result => {
                     this.errors.splice(index, 1);
                     this._settingsservice.setErrors(this.errors); // update service

--- a/src/app/settings/categories/managers/managers.component.ts
+++ b/src/app/settings/categories/managers/managers.component.ts
@@ -69,13 +69,13 @@ export class ManagersComponent implements OnInit {
     }
 
     ngOnInit() {
-        this._settingsservice.getEntities(this.configSettings.regionURL).subscribe(regions => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL).subscribe(regions => {
             this.regions = regions;
         });
-        this._settingsservice.getEntities(this.configSettings.managersURL).subscribe(managers => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.managersURL).subscribe(managers => {
             this.managers = managers;
         });
-        this._settingsservice.getEntities(this.configSettings.rolesURL).subscribe(roles => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.rolesURL).subscribe(roles => {
             this.roles = roles;
         });
     }
@@ -159,7 +159,7 @@ export class ManagersComponent implements OnInit {
             this.newUserForm.value.regionManagers.forEach(x => this.removeRegion(x));
         }
         const newUser = this.newUserForm.value;
-        this._settingsservice.postEntity(newUser, this.configSettings.managersURL).subscribe(
+        this._settingsservice.postEntity(newUser, this.configSettings.nssBaseURL + this.configSettings.managersURL).subscribe(
             (response: Manager) => {
                 response.isEditing = false;
                 this.managers.push(response);
@@ -197,7 +197,7 @@ export class ManagersComponent implements OnInit {
             this._toasterService.pop('error', 'Error updating Manager', 'First name, last name, username, email and role are required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntity(u.id, u, this.configSettings.managersURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.nssBaseURL + this.configSettings.managersURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.managers[i] = u;
@@ -220,7 +220,7 @@ export class ManagersComponent implements OnInit {
         if (check) {
             // delete it
             const index = this.managers.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntity(deleteID, this.configSettings.managersURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.nssBaseURL + this.configSettings.managersURL)
                 .subscribe(result => {
                     this.managers.splice(index, 1);
                     this._settingsservice.setManagers(this.managers); // update service

--- a/src/app/settings/categories/methods/methods.component.ts
+++ b/src/app/settings/categories/methods/methods.component.ts
@@ -18,7 +18,7 @@ export class MethodsComponent implements OnInit {
 
   ngOnInit() {
       // get all method types
-      this._settingsService.getEntities(this.configSettings.methodURL).subscribe(res => {
+      this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.methodURL).subscribe(res => {
         this.methods = res;
     });
   }

--- a/src/app/settings/categories/regions/regions.component.ts
+++ b/src/app/settings/categories/regions/regions.component.ts
@@ -60,7 +60,7 @@ export class RegionsComponent implements OnInit, OnDestroy {
         }
 
     ngOnInit() {
-        this._settingsservice.getEntities(this.configSettings.regionURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL).subscribe(res => {
             this.regions = res;
         });
 
@@ -102,7 +102,7 @@ export class RegionsComponent implements OnInit, OnDestroy {
 
     private createNewRegion() {
         const newItem = this.newRegForm.value;
-        this._settingsservice.postEntity(newItem, this.configSettings.regionURL)
+        this._settingsservice.postEntity(newItem, this.configSettings.nssBaseURL + this.configSettings.regionURL)
             .subscribe((response: Region) => {
                 response.isEditing = false;
                 this.regions.push(response);
@@ -140,7 +140,7 @@ export class RegionsComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Region', 'Name and Code are required.');
         } else {
             delete r.isEditing;
-            this._settingsservice.putEntity(r.id, r, this.configSettings.regionURL).subscribe(
+            this._settingsservice.putEntity(r.id, r, this.configSettings.nssBaseURL + this.configSettings.regionURL).subscribe(
                 (resp) => {
                     r.isEditing = false;
                     this.regions[i] = r;
@@ -163,7 +163,7 @@ export class RegionsComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.regions.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntity(deleteID, this.configSettings.regionURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.nssBaseURL + this.configSettings.regionURL)
                 .subscribe(result => {
                     this.regions.splice(index, 1);
                     this._settingsservice.setRegions(this.regions); // update service

--- a/src/app/settings/categories/regressiontypes/regressiontypes.component.ts
+++ b/src/app/settings/categories/regressiontypes/regressiontypes.component.ts
@@ -74,16 +74,16 @@ export class RegressionTypesComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this._settingsservice.getEntities(this.configSettings.regionURL).subscribe(reg => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL).subscribe(reg => {
             this.regions = reg;
         });
-        this._settingsservice.getEntities(this.configSettings.statisticGrpURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.statisticGrpURL).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             this.selectedStatisticGroups = res;
         });
         this.selectedStatistic = 'none';
         this.selectedRegion = 'none';
-        this._settingsservice.getEntities(this.configSettings.regTypeURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regTypeURL).subscribe(res => {
             this.regressionTypes = res;
         });
     }
@@ -98,7 +98,7 @@ export class RegressionTypesComponent implements OnInit, OnDestroy {
             this.selectedStatisticID = "";
         }
         this._settingsservice
-            .getEntities(this.configSettings.regTypeURL+"?regions="+ this.selectedRegionID +"&statisticgroups="+ this.selectedStatisticID)
+            .getEntities(this.configSettings.nssBaseURL + this.configSettings.regTypeURL+"?regions="+ this.selectedRegionID +"&statisticgroups="+ this.selectedStatisticID)
             .subscribe(regs => {
                 this.regressionTypes = regs;
             });
@@ -114,14 +114,14 @@ export class RegressionTypesComponent implements OnInit, OnDestroy {
         if(this.selectedRegion === 'none'){
             this.selectedRegionID = "";
         }
-        this._settingsservice.getEntities(this.configSettings.regTypeURL+"?regions="+ this.selectedRegionID +"&statisticgroups="+ this.selectedStatisticID).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regTypeURL+"?regions="+ this.selectedRegionID +"&statisticgroups="+ this.selectedStatisticID).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             this.regressionTypes = res;
         });
     }
 
     public getAllRegTypes() {
-        this._settingsservice.getEntities(this.configSettings.regTypeURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regTypeURL).subscribe(res => {
             this.regressionTypes = res;
         });
     }
@@ -169,7 +169,7 @@ export class RegressionTypesComponent implements OnInit, OnDestroy {
 
     private createNewRegression() {
         const newReg = this.newRegForm.value;
-        this._settingsservice.postEntity(newReg, this.configSettings.regTypeURL).subscribe(
+        this._settingsservice.postEntity(newReg, this.configSettings.nssBaseURL + this.configSettings.regTypeURL).subscribe(
             (response: Regressiontype) => {
                 response.isEditing = false;
                 this._toasterService.pop('info', 'Info', 'Regression type was created');
@@ -210,7 +210,7 @@ export class RegressionTypesComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Regression Type', 'Name, description and Code are required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntity(u.id, u, this.configSettings.regTypeURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.nssBaseURL + this.configSettings.regTypeURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.regressionTypes[i] = u;
@@ -233,7 +233,7 @@ export class RegressionTypesComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.regressionTypes.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntity(deleteID, this.configSettings.regTypeURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.nssBaseURL + this.configSettings.regTypeURL)
                 .subscribe(result => {
                     this.regressionTypes.splice(index, 1);
                     this._settingsservice.setRegTypes(this.regressionTypes); // update service

--- a/src/app/settings/categories/stationtypes/stationtypes.component.ts
+++ b/src/app/settings/categories/stationtypes/stationtypes.component.ts
@@ -70,7 +70,7 @@ export class StationTypesComponent implements OnInit, OnDestroy {
         }
 
     ngOnInit() {
-        this._settingsservice.getEntitiesGageStats(this.configSettings.stationTypeURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.gageStatsBaseURL + this.configSettings.stationTypeURL).subscribe(res => {
             this.stationTypes = <Array<any>>res;
         });
 
@@ -119,7 +119,7 @@ export class StationTypesComponent implements OnInit, OnDestroy {
 
     private createNewStationType() {
         const newItem = this.newStationTypeForm.value;
-        this._settingsservice.postEntityGageStats(newItem, this.configSettings.stationTypeURL)
+        this._settingsservice.postEntity(newItem, this.configSettings.gageStatsBaseURL + this.configSettings.stationTypeURL)
             .subscribe((response: StationType) => {
                 response.isEditing = false;
                 this.stationTypes.push(response);
@@ -157,7 +157,7 @@ export class StationTypesComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Station Type', 'Name and Code are required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntityGageStats(u.id, u, this.configSettings.stationTypeURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.gageStatsBaseURL + this.configSettings.stationTypeURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.stationTypes[i] = u;
@@ -180,7 +180,7 @@ export class StationTypesComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.stationTypes.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntityGageStats(deleteID, this.configSettings.stationTypeURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.gageStatsBaseURL + this.configSettings.stationTypeURL)
                 .subscribe(result => {
                     this.stationTypes.splice(index, 1);
                     this._settingsservice.setStationTypes(this.stationTypes); // update service

--- a/src/app/settings/categories/statisticgroups/statisticgroups.component.ts
+++ b/src/app/settings/categories/statisticgroups/statisticgroups.component.ts
@@ -66,7 +66,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
         }
 
     ngOnInit() {
-        this._settingsservice.getEntities(this.configSettings.regionURL).subscribe(regions => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL).subscribe(regions => {
             this.regions = regions;
         });
         this.selectedRegion = 'none';
@@ -77,7 +77,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
         });
     }
     public getAllStatGroups() {
-        this._settingsservice.getEntities(this.configSettings.statisticGrpURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.statisticGrpURL).subscribe(res => {
             this.allStatGroups = res;
             if (this.selectedRegion === 'none') {this.statisticGroups = res; }
         });
@@ -91,7 +91,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
     }
 
     private getStatGroups(r) {
-        this._settingsservice.getEntities(this.configSettings.regionURL + r.id + '/' + this.configSettings.statisticGrpURL)
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + r.id + '/' + this.configSettings.statisticGrpURL)
             .subscribe(res => {
                 this.statisticGroups = res;
         });
@@ -130,7 +130,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
 
     private createNewStatGroup() {
         const newStatGroup = this.newStatGroupForm.value;
-        this._settingsservice.postEntity(newStatGroup, this.configSettings.statisticGrpURL)
+        this._settingsservice.postEntity(newStatGroup, this.configSettings.nssBaseURL + this.configSettings.statisticGrpURL)
             .subscribe((response: Statisticgroup) => {
                 response.isEditing = false;
                 this.cancelCreateStatGroup();
@@ -168,7 +168,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Statistic Group', 'Name and Code are required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntity(u.id, u, this.configSettings.statisticGrpURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.nssBaseURL + this.configSettings.statisticGrpURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.statisticGroups[i] = u;
@@ -191,7 +191,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.statisticGroups.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntity(deleteID, this.configSettings.statisticGrpURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.nssBaseURL + this.configSettings.statisticGrpURL)
                 .subscribe(result => {
                     this.statisticGroups.splice(index, 1);
                     this._settingsservice.setStatGroups(this.statisticGroups); // update service

--- a/src/app/settings/categories/unitsystems/unitsystems.component.ts
+++ b/src/app/settings/categories/unitsystems/unitsystems.component.ts
@@ -66,7 +66,7 @@ export class UnitSystemsComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.isEditing = false;
-        this._settingsservice.getEntities(this.configSettings.unitSystemsURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.unitSystemsURL).subscribe(res => {
             this.unitSystems = res;
         });
 
@@ -117,7 +117,7 @@ export class UnitSystemsComponent implements OnInit, OnDestroy {
 
     private createNewUnit() {
         const newUnit = this.newUnitSystemForm.value;
-        this._settingsservice.postEntity(newUnit, this.configSettings.unitSystemsURL).subscribe(
+        this._settingsservice.postEntity(newUnit, this.configSettings.nssBaseURL + this.configSettings.unitSystemsURL).subscribe(
             (response: UnitSystem) => {
                 response.isEditing = false;
                 this.unitSystems.push(response);
@@ -156,7 +156,7 @@ export class UnitSystemsComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Unit System', 'Unit System Name is required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntity(u.id, u, this.configSettings.unitSystemsURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.nssBaseURL + this.configSettings.unitSystemsURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.unitSystems[i] = u;
@@ -179,7 +179,7 @@ export class UnitSystemsComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.unitSystems.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntity(deleteID, this.configSettings.unitSystemsURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.nssBaseURL + this.configSettings.unitSystemsURL)
                 .subscribe(result => {
                     this.unitSystems.splice(index, 1);
                     this._settingsservice.setUnitSystems(this.unitSystems); // update service

--- a/src/app/settings/categories/unittypes/unittypes.component.ts
+++ b/src/app/settings/categories/unittypes/unittypes.component.ts
@@ -74,10 +74,10 @@ export class UnitTypesComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.isEditing = false;
-        this._settingsservice.getEntities(this.configSettings.unitsURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.unitsURL).subscribe(res => {
             this.unitTypes = res;
         });
-        this._settingsservice.getEntities(this.configSettings.unitSystemsURL).subscribe(usys => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.unitSystemsURL).subscribe(usys => {
             this.unitSystems = usys;
         });
 
@@ -130,7 +130,7 @@ export class UnitTypesComponent implements OnInit, OnDestroy {
 
     private createNewUnit() {
         const newUnit = this.newUnitForm.value;
-        this._settingsservice.postEntity(newUnit, this.configSettings.unitsURL)
+        this._settingsservice.postEntity(newUnit, this.configSettings.nssBaseURL + this.configSettings.unitsURL)
             .subscribe((response: Unittype) => {
                 response.isEditing = false;
                 this.unitTypes.push(response);
@@ -169,7 +169,7 @@ export class UnitTypesComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Unit', 'Name, abbreviation and unit system ID are required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntity(u.id, u, this.configSettings.unitsURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.nssBaseURL + this.configSettings.unitsURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.unitTypes[i] = u;
@@ -192,7 +192,7 @@ export class UnitTypesComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.unitTypes.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntity(deleteID, this.configSettings.unitsURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.nssBaseURL + this.configSettings.unitsURL)
                 .subscribe(result => {
                     this.unitTypes.splice(index, 1);
                     this._settingsservice.setUnits(this.unitTypes); // update service

--- a/src/app/settings/categories/variabletypes/variabletypes.component.ts
+++ b/src/app/settings/categories/variabletypes/variabletypes.component.ts
@@ -64,14 +64,14 @@ export class VariableTypesComponent implements OnInit, OnDestroy {
         }
 
     ngOnInit() {
-        this._settingsservice.getEntities(this.configSettings.variablesURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.variablesURL).subscribe(res => {
             this.variableTypes = res;
         });
 
         this._settingsservice.variables().subscribe(res => {
             this.variableTypes = res;
         });
-        this._settingsservice.getEntities(this.configSettings.unitsURL).subscribe(res => {
+        this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.unitsURL).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             for (const unit of res) {
                 unit['unit'] = unit['name'];
@@ -116,7 +116,7 @@ export class VariableTypesComponent implements OnInit, OnDestroy {
 
     private createNewVariableType() {
         const newItem = this.newVarForm.value;
-        this._settingsservice.postEntity(newItem, this.configSettings.variablesURL)
+        this._settingsservice.postEntity(newItem, this.configSettings.nssBaseURL + this.configSettings.variablesURL)
             .subscribe((response: Variabletype) => {
                 response.isEditing = false;
                 this.variableTypes.push(response);
@@ -162,7 +162,7 @@ export class VariableTypesComponent implements OnInit, OnDestroy {
             this._toasterService.pop('error', 'Error updating Variable', 'Name, description and Code are required.');
         } else {
             delete u.isEditing;
-            this._settingsservice.putEntity(u.id, u, this.configSettings.variablesURL).subscribe(
+            this._settingsservice.putEntity(u.id, u, this.configSettings.nssBaseURL + this.configSettings.variablesURL).subscribe(
                 (resp) => {
                     u.isEditing = false;
                     this.variableTypes[i] = u;
@@ -185,7 +185,7 @@ export class VariableTypesComponent implements OnInit, OnDestroy {
         if (check) {
             // delete it
             const index = this.variableTypes.findIndex(item => item.id === deleteID);
-            this._settingsservice.deleteEntity(deleteID, this.configSettings.variablesURL)
+            this._settingsservice.deleteEntity(deleteID, this.configSettings.nssBaseURL + this.configSettings.variablesURL)
                 .subscribe(result => {
                     this.variableTypes.splice(index, 1);
                     this._settingsservice.setVariables(this.variableTypes); // update service

--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -116,22 +116,15 @@ export class SettingsService {
     // ------------ GETS ---------------------------
     public getEntities(url: string) {
         return this._http
-            .get(this.configSettings.nssBaseURL + url, { headers: this.authHeader })
+            .get(url, { headers: this.authHeader })
             .map(res => { if (res) {return <Array<any>>res }})
-            .catch(this.errorHandler);
-    }
-
-    public getEntitiesGageStats(url: string) {
-        return this._http
-            .get(this.configSettings.gageStatsBaseURL + url, { headers: this.authHeader })
-            .map(res => res)//{ if (res) {return <Array<any>>res }}) Out response as object instead of array.
             .catch(this.errorHandler);
     }
 
     // ------------ POSTS ------------------------------
     public postEntity(entity: object, url: string) {
         return this._http
-            .post(this.configSettings.nssBaseURL + url, entity, { headers: this.authHeader, observe: 'response' })
+            .post(url, entity, { headers: this.authHeader, observe: 'response' })
             .map(res => {
                 if (!res.headers) {this._toasterService.pop('info', 'Info', 'Regression region was added');
                 } else {this.outputWimMessages(res); }
@@ -140,31 +133,11 @@ export class SettingsService {
             .catch(this.errorHandler);
     }
 
-    public postEntityGageStats(entity: object, url: string) {
-        return this._http
-            .post(this.configSettings.gageStatsBaseURL + url, entity, { headers: this.authHeader, observe: 'response' })
-            .map(res => {
-                if (!res.headers) {this._toasterService.pop('info', 'Info', 'New item was added');
-                } else {
-                    this.outputWimMessages(res); }
-                return res.body;
-            })
-            .catch(this.errorHandler); 
-    }
-
     // ------------ PUTS --------------------------------
     public putEntity(id, entity, url: string) {
         if (id !== '') {url += '/' + id; }
         return this._http
-            .put(this.configSettings.nssBaseURL + url, entity, { headers: this.authHeader, observe: 'response' })
-            .map(res => res)
-            .catch(this.errorHandler);
-    }
-
-    public putEntityGageStats(id, entity, url: string) {
-        if (id !== '') {url += '/' + id; }
-        return this._http
-            .put(this.configSettings.gageStatsBaseURL + url, entity, { headers: this.authHeader, observe: 'response' })
+            .put(url, entity, { headers: this.authHeader, observe: 'response' })
             .map(res => res)
             .catch(this.errorHandler);
     }
@@ -173,14 +146,7 @@ export class SettingsService {
     public deleteEntity(id, url: string, params?: string) {
         if (id !== '') {url += '/' + id; }
         if (params) {url += params; }
-        return this._http.delete(this.configSettings.nssBaseURL + url, { headers: this.authHeader, observe: 'response'})
-            .catch(this.errorHandler);
-    }
-
-    public deleteEntityGageStats(id, url: string, params?: string) {
-        if (id !== '') {url += '/' + id; }
-        if (params) {url += params; }
-        return this._http.delete(this.configSettings.gageStatsBaseURL + url, { headers: this.authHeader, observe: 'response'})
+        return this._http.delete( url, { headers: this.authHeader, observe: 'response'})
             .catch(this.errorHandler);
     }
 

--- a/src/app/shared/components/addregressionregion/addregressionregion.component.ts
+++ b/src/app/shared/components/addregressionregion/addregressionregion.component.ts
@@ -208,7 +208,8 @@ export class AddRegressionRegionModal implements OnInit, OnDestroy {
   public showManageCitationsModal() {
     const addManageCitationForm: ManageCitation = {
       show: true,
-      addCitation: false
+      addCitation: false,
+      inGagePage: false
     }
     this._nssService.setManageCitationsModal(addManageCitationForm);
   }

--- a/src/app/shared/components/addregressionregion/addregressionregion.component.ts
+++ b/src/app/shared/components/addregressionregion/addregressionregion.component.ts
@@ -125,10 +125,10 @@ export class AddRegressionRegionModal implements OnInit, OnDestroy {
     this._nssService.selectedRegRegions.subscribe((regRegions: Array<Regressionregion>) => {
       this.selectedRegressionRegion = regRegions;
     });
-    this._settingsService.getEntities(this.configSettings.statusURL).subscribe(res => {
+    this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.statusURL).subscribe(res => {
       this.status = res;
     });
-    this._settingsService.getEntities(this.configSettings.methodURL).subscribe(res => {
+    this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.methodURL).subscribe(res => {
       this.methods = res;
     });
     this._nssService.currentCitation.subscribe(item => {
@@ -251,7 +251,7 @@ export class AddRegressionRegionModal implements OnInit, OnDestroy {
     if (rr) { // edit existing regression region
       this._loaderService.showFullPageLoad();
       this.addRegReg = false;
-      this._settingsService.getEntities(this.configSettings.regRegionURL + '/' + rr + '?includeGeometry=true')
+      this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.regRegionURL + '/' + rr + '?includeGeometry=true')
         .subscribe((res) => {
           this.selectedRegRegion = res;
           // set values in add regression region modal
@@ -264,7 +264,7 @@ export class AddRegressionRegionModal implements OnInit, OnDestroy {
           if (this.selectedRegRegion.citationID) { // if there is a citation set values in modal
             this.newRegRegForm.controls['citationID'].setValue(this.selectedRegRegion.citationID);
             this.addCitation = true;
-            this._settingsService.getEntities(this.configSettings.citationURL + '/' + this.selectedRegRegion.citationID)
+            this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.citationURL + '/' + this.selectedRegRegion.citationID)
               .subscribe(res => {
                   this.selectedCitation = res;
                   this.newCitForm.controls['title'].setValue(this.selectedCitation.title);
@@ -328,7 +328,7 @@ export class AddRegressionRegionModal implements OnInit, OnDestroy {
         this.newRegRegForm.get('location').setValue(null);
     }
     this._settingsService
-      .postEntity(this.newRegRegForm.value, this.configSettings.regionURL + regionID + '/' + this.configSettings.regRegionURL)
+      .postEntity(this.newRegRegForm.value, this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + regionID + '/' + this.configSettings.regRegionURL)
       .subscribe((response:any) => {
         response.isEditing = false;
         if (!response.headers) {
@@ -354,7 +354,7 @@ export class AddRegressionRegionModal implements OnInit, OnDestroy {
     if (!this.uploadPolygon) { // No polygon
       this.newRegRegForm.get('location').setValue(null);
     }
-    this._settingsService.putEntity(this.selectedRegRegion.id, this.newRegRegForm.value, this.configSettings.regRegionURL).subscribe(res => {
+    this._settingsService.putEntity(this.selectedRegRegion.id, this.newRegRegForm.value, this.configSettings.nssBaseURL + this.configSettings.regRegionURL).subscribe(res => {
       if (!res.headers) {
         this._toasterService.pop('info', 'Info', 'Regression Region was updated');
         this.modalRef.close();
@@ -362,7 +362,7 @@ export class AddRegressionRegionModal implements OnInit, OnDestroy {
         this._settingsService.outputWimMessages(res); 
       }
       if (this.addCitation && this.selectedRegRegion.citationID) { // Editing existing citation (moving into manage citaion modal)
-        this._settingsService.putEntity(this.selectedRegRegion.citationID, this.newCitForm.value, this.configSettings.citationURL)
+        this._settingsService.putEntity(this.selectedRegRegion.citationID, this.newCitForm.value, this.configSettings.nssBaseURL + this.configSettings.citationURL)
           .subscribe((response: any) => {
             if (!response.headers) { // Citation successfully updated
               this._toasterService.pop('info', 'Info', 'Citation was updated');
@@ -403,7 +403,7 @@ export class AddRegressionRegionModal implements OnInit, OnDestroy {
 
   public createNewCitation(rr) {
     // add new citation
-    this._settingsService.postEntity(this.newCitForm.value, this.configSettings.regRegionURL + '/' + rr.id + '/' +
+    this._settingsService.postEntity(this.newCitForm.value, this.configSettings.nssBaseURL + this.configSettings.regRegionURL + '/' + rr.id + '/' +
       this.configSettings.citationURL)
       .subscribe((response: any) => {
         this.newCitForm.reset();

--- a/src/app/shared/components/addscenario/addscenario.component.ts
+++ b/src/app/shared/components/addscenario/addscenario.component.ts
@@ -134,23 +134,23 @@ export class AddScenarioModal implements OnInit, OnDestroy {
     }
     
     public getEntities(){   // Moved to own function in order to reload properties in case new property was added in settings
-        this._settingsService.getEntities(this.configSettings.regionURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             this.regions = res;
         });
-        this._settingsService.getEntities(this.configSettings.statisticGrpURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.statisticGrpURL).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             this.statisticGroups = res;
         });
-        this._settingsService.getEntities(this.configSettings.regTypeURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.regTypeURL).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             this.regressionTypes = res;
         });
-        this._settingsService.getEntities(this.configSettings.variablesURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.variablesURL).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             this.variables = res;
         });
-        this._settingsService.getEntities(this.configSettings.unitsURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.unitsURL).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             for (const unit of res) {
                 unit['unit'] = unit['name'];
@@ -158,7 +158,7 @@ export class AddScenarioModal implements OnInit, OnDestroy {
             }
             this.unitTypes = res;
         });
-        this._settingsService.getEntities(this.configSettings.errorsURL).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.errorsURL).subscribe(res => {
             res.sort((a, b) => a.name.localeCompare(b.name));
             this.errors = res;
         });
@@ -421,7 +421,7 @@ export class AddScenarioModal implements OnInit, OnDestroy {
         scen['regressionRegions'] = [regRegs];
 
         // post scenario
-        this._settingsService.postEntity(scen, this.configSettings.scenariosURL + '?statisticgroupIDorCode=' + scen.statisticGroupID)
+        this._settingsService.postEntity(scen, this.configSettings.nssBaseURL + this.configSettings.scenariosURL + '?statisticgroupIDorCode=' + scen.statisticGroupID)
             .subscribe((response: any) => {
                 if(this.originalRegion==this.selectedRegion){
                     this._nssService.selectedStatGroups = this.tempSelectedStatisticGrp;

--- a/src/app/shared/components/managecitations/managecitations.component.html
+++ b/src/app/shared/components/managecitations/managecitations.component.html
@@ -45,8 +45,8 @@
 					<tr>
 						<th class="width-60">Citation</th>
 						<th class="width-5"></th>
-						<th class="width-35">Associated Regression Regions</th>
-						<th class="width-5 empty-cell">
+						<th class="width-35" *ngIf="!inGagePage">Associated Regression Regions</th>
+						<th class="width-5 empty-cell" *ngIf="!inGagePage">
 							<!-- Filler button - not used for anything -->
 							<div class="cell-buttons"><button class="icon-button" aria-hidden="true"><i class="far fa-circle"></i></button></div>
 						</th>
@@ -55,7 +55,7 @@
 				<tbody>
 					<tr *ngFor="let c of filteredData; let cIndex = index">
 						<!-- Col 1, Citation -->
-						<td class="width-60">
+						<td class="width-60" (click)= "setSelectedCitation(c); d('closed')">
 							<div class="half-space">
 								<span *ngIf="!c.isEditing">{{ c.author }}</span>
 								<span *ngIf="c.isEditing"><textarea class='break' name="author" [(ngModel)]="c.author" required></textarea></span>
@@ -96,11 +96,11 @@
 							</div>
 						</td>
 						<!-- Col 3, Associated Regression Region and Buttons -->
-						<td class="width-35">
+						<td class="width-35" *ngIf="!inGagePage">
 							<div *ngFor="let e of c.regressionRegions; let lst = last;">{{e.name}}<span *ngIf = "!lst"><hr></span></div>
 						</td>
 						<!-- Col 4 - Regression Buttons -->
-						<td class="width-5">
+						<td class="width-5" *ngIf="!inGagePage">
 							<div *ngFor="let e of c.regressionRegions; let lst = last;" [class.hidden]="!showAddCitations" class="cell-buttons">
 								<button title="Edit Regression Region" (click)="editRegRegion(e.id)" class="icon-button" [disabled]="!checkManagerRegressionRegions(e)" aria-hidden="true">
 									<i class="far fa-pencil"></i>

--- a/src/app/shared/components/managecitations/managecitations.component.html
+++ b/src/app/shared/components/managecitations/managecitations.component.html
@@ -47,7 +47,7 @@
 			</form>
 
 			
-			<table class="custom-table table-striped table-scroll mtop-sm no-scrollbars" [class.table-hover-rows]="inGagePage">
+			<table class="custom-table table-striped table-scroll mtop-sm no-scrollbars" [class.table-hover-rows]="inGagePage && !inGageStats">
 				<thead>
 					<tr>
 						<th *ngIf="inGagePage" class="width-5">ID</th>

--- a/src/app/shared/components/managecitations/managecitations.component.html
+++ b/src/app/shared/components/managecitations/managecitations.component.html
@@ -114,23 +114,22 @@
 						</td>
 						<!-- Col 3, Associated Regression Region -->
 						<td *ngIf="!inGagePage">
-						<div *ngFor="let e of c.regressionRegions; last as isLast" class=regRegionFields>
+							<div *ngFor="let e of c.regressionRegions; last as isLast">
 								<!-- Col 3, Associated Regression Region (all but the last one) -->
-								<td [class.regRegionLast]=isLast [class.regRegion]=!isLast>{{e.name}}
-								</td>
+								<td [class.regRegionLast]=isLast [class.regRegion]=!isLast>{{e.name}}</td>
 								<!-- Col 4 - Regression Buttons -->
 								<td [class.editRegRegionLast]=isLast [class.editRegRegion]=!isLast [class.hidden]="!showAddCitations">
 									<button title="Edit Regression Region" (click)="editRegRegion(e.id)" class="icon-button"
 										[disabled]="!checkManagerRegressionRegions(e)" aria-hidden="true">
 										<i class="far fa-pencil"></i>
-									</button></td>
-						</div>
+									</button>
+								</td>
+							</div>
 						</td>
 					</tr>
 				</tbody>
-			</table>
-		
-	</div>
+			</table>		
+		</div>
 	</div>
 
 	<!-- Footer / Buttons -->

--- a/src/app/shared/components/managecitations/managecitations.component.html
+++ b/src/app/shared/components/managecitations/managecitations.component.html
@@ -47,14 +47,13 @@
 			</form>
 
 			
-			<table class="custom-table table-striped table-scroll mtop-sm no-scrollbars">
+			<table class="custom-table table-striped table-scroll mtop-sm no-scrollbars" [class.table-hover-rows]="inGagePage">
 				<thead>
 					<tr>
-						<th *ngIf="!inGagePage" class=citationHeader>Citation</th>
-						<th *ngIf="!inGagePage" class=citationEditHeader></th>
 						<th *ngIf="inGagePage" class="width-5">ID</th>
-						<th *ngIf="inGagePage" class="width-85">Citation</th>
-						<th *ngIf="inGagePage" class="width-10"></th>
+						<th [class.citationHeader]="!inGagePage" [class.width-85]="inGagePage">Citation</th>
+						<th [class.citationEditHeader]="!inGagePage" [class.width-10]="inGagePage"></th>
+						<!-- <th *ngIf="inGagePage" class="width-10"></th> -->
 						<th class=regRegionHeader *ngIf="!inGagePage">Associated Regression Regions</th>
 						<th class="empty-cell regRegionEditHeader" *ngIf="!inGagePage">
 							<!-- Filler button - not used for anything -->
@@ -63,118 +62,62 @@
 					</tr>
 				</thead>
 				<tbody>
-					<tr *ngFor="let c of filteredData; let cIndex = index">
-						<!-- When the Citation Modal is not opened in the GagePage -->
-						<ng-container *ngIf="!inGagePage">	
-							<!-- Col 1, Citation -->
-							<td class=col1>
-								<div class="half-space">
-									<span *ngIf="!c.isEditing">{{ c.author }}</span>
-									<span *ngIf="c.isEditing"><textarea class='break' name="author" [(ngModel)]="c.author"
-											required></textarea></span>
-								</div>
-								<div>
-									<span *ngIf="!c.isEditing">{{ c.title }}</span>
-									<span *ngIf="c.isEditing"><textarea class='break' name="title" [(ngModel)]="c.title"
-											required></textarea></span>
-								</div>
-								<div>
-									<a *ngIf="!c.isEditing" [href]="c.citationURL" [target]="_blank">
-										<span *ngIf="!c.isEditing">{{ c.citationURL }}</span>
-									</a>
-									<span *ngIf="c.isEditing"><textarea class='break' name="citationURL"
-											[(ngModel)]="c.citationURL" required></textarea></span>
-								</div>
-							</td>
-							<!-- Col 2 - Citation Buttons -->
-							<td class=editCol>
-								<!-- Editing -->
-								<div [class.hidden]="!showAddCitations" class="cell-buttons">
-									<button *ngIf="!c.isEditing" title="Edit Citation" (click)="editRowClicked(c, cIndex)"
-										class="icon-button" [disabled]="!checkManagerCitations(c)" aria-hidden="true">
-										<i class="far fa-pencil"></i>
-									</button>
-									<button *ngIf="c.isEditing" title="Save Citation" (click)="saveCitation(c)"
-										class="icon-button" aria-hidden="true">
-										<i class="far fa-floppy-o"></i>
-									</button>
-									<button *ngIf="c.isEditing" title="Cancel Edit" (click)="CancelEditRowClicked()"
-										class="icon-button" aria-hidden="true">
-										<i class="far fa-history"></i>
-									</button>
-									<button *ngIf="loggedInRole === 'Administrator' && !c.isEditing" title="Delete Citation"
-										(click)="deleteCitation(c.id)" class="icon-button"
-										[disabled]="c.regressionRegions?.length>0" aria-hidden="true">
-										<i class="far fa-times"></i>
-									</button>
-								</div>
-								<!-- Not editing -->
-								<div [class.hidden]="showAddCitations" class="cell-buttons">
-									<button title="Add Citation" (click)="addExistingCitation(c); d('closed')"
-										class="icon-button" aria-hidden="true">
-										<i class="far fa-plus"></i>
-									</button>
-								</div>
-							</td>
-						</ng-container>
-						<!-- When the Citation Modal is opened in the GagePage -->
-						<ng-container *ngIf="inGagePage">	
-							<!-- Col 1 -->
-							<td class="width-5">
-								<div >{{c.id}}</div>
-							</td>
-							<!-- Col 2, Citation -->
-							<td class="width-85" (click)= "setSelectedCitation(c); d('closed')">
-								<div class="half-space">
-									<span *ngIf="!c.isEditing">{{ c.author }}</span>
-									<span *ngIf="c.isEditing"><textarea class='break' name="author" [(ngModel)]="c.author"
-											required></textarea></span>
-								</div>
-								<div>
-									<span *ngIf="!c.isEditing">{{ c.title }}</span>
-									<span *ngIf="c.isEditing"><textarea class='break' name="title" [(ngModel)]="c.title"
-											required></textarea></span>
-								</div>
-								<div>
-									<a *ngIf="!c.isEditing" [href]="c.citationURL" [target]="_blank">
-										<span *ngIf="!c.isEditing">{{ c.citationURL }}</span>
-									</a>
-									<span *ngIf="c.isEditing"><textarea class='break' name="citationURL"
-											[(ngModel)]="c.citationURL" required></textarea></span>
-								</div>
-							</td>
-							<!-- Col 2 - Citation Buttons -->
-							<td class="width-10">
-								<!-- Editing -->
-								<div [class.hidden]="!showAddCitations" class="cell-buttons">
-									<button *ngIf="!c.isEditing" title="Edit Citation" (click)="editRowClicked(c, cIndex)"
-										class="icon-button" [disabled]="!checkManagerCitations(c)" aria-hidden="true">
-										<i class="far fa-pencil"></i>
-									</button>
-									<button *ngIf="c.isEditing" title="Save Citation" (click)="saveCitation(c)"
-										class="icon-button" aria-hidden="true">
-										<i class="far fa-floppy-o"></i>
-									</button>
-									<button *ngIf="c.isEditing" title="Cancel Edit" (click)="CancelEditRowClicked()"
-										class="icon-button" aria-hidden="true">
-										<i class="far fa-history"></i>
-									</button>
-									<button *ngIf="loggedInRole === 'Administrator' && !c.isEditing" title="Delete Citation"
-										(click)="deleteCitation(c.id)" class="icon-button"
-										[disabled]="c.regressionRegions?.length>0" aria-hidden="true">
-										<i class="far fa-times"></i>
-									</button>
-								</div>
-								<!-- Not editing -->
-								<div [class.hidden]="showAddCitations" class="cell-buttons">
-									<button title="Add Citation" (click)="addExistingCitation(c); d('closed')"
-										class="icon-button" aria-hidden="true">
-										<i class="far fa-plus"></i>
-									</button>
-								</div>
-							</td>
-						</ng-container>
-						<!-- Col 3, Associated Regression Region -->
+					<tr *ngFor="let c of filteredData; let cIndex = index" [ngClass]="{'selectedRow': selectedRow === c.id}">
+						<!-- Col 1 -->
+						<td *ngIf="inGagePage" class="width-5">
+							<div>{{c.id}}</div>
+						</td>
+						<!-- Col 2, Citation -->
+						<td [class.col1]="!inGagePage" [class.width-85]='inGagePage' (click)= "!inGageStats && inGagePage && setSelectedCitation(c)">
+							<div class="half-space">
+								<span *ngIf="!c.isEditing">{{ c.author }}</span>
+								<span *ngIf="c.isEditing"><textarea class='break' name="author" [(ngModel)]="c.author"
+										required></textarea></span>
+							</div>
+							<div>
+								<span *ngIf="!c.isEditing">{{ c.title }}</span>
+								<span *ngIf="c.isEditing"><textarea class='break' name="title" [(ngModel)]="c.title"
+										required></textarea></span>
+							</div>
+							<div>
+								<a *ngIf="!c.isEditing" [href]="c.citationURL" [target]="_blank">
+									<span *ngIf="!c.isEditing">{{ c.citationURL }}</span>
+								</a>
+								<span *ngIf="c.isEditing"><textarea class='break' name="citationURL"
+										[(ngModel)]="c.citationURL" required></textarea></span>
+							</div>
+						</td>
+						<!-- Col 3 - Citation Buttons -->
+						<td [class.editCol]='!inGagePage' [class.width-10]="inGagePage">
+							<!-- Editing -->
+							<div [class.hidden]="!showAddCitations" class="cell-buttons">
+								<button *ngIf="!c.isEditing" title="Edit Citation" (click)="editRowClicked(c, cIndex)"
+									class="icon-button" [disabled]="!checkManagerCitations(c)" aria-hidden="true">
+									<i class="far fa-pencil"></i>
+								</button>
+								<button *ngIf="c.isEditing" title="Save Citation" (click)="saveCitation(c)"
+									class="icon-button" aria-hidden="true">
+									<i class="far fa-floppy-o"></i>
+								</button>
+								<button *ngIf="c.isEditing" title="Cancel Edit" (click)="CancelEditRowClicked()"
+									class="icon-button" aria-hidden="true">
+									<i class="far fa-history"></i>
+								</button>
+								<button *ngIf="loggedInRole === 'Administrator' && !c.isEditing" title="Delete Citation"
+									(click)="deleteCitation(c.id)" class="icon-button"
+									[disabled]="c.regressionRegions?.length>0" aria-hidden="true">
+									<i class="far fa-times"></i>
+								</button>
+							</div>
+							<!-- Not editing -->
+							<div [class.hidden]="showAddCitations" class="cell-buttons">
+								<button title="Add Citation" (click)="addExistingCitation(c); d('closed')"
+									class="icon-button" aria-hidden="true">
+									<i class="far fa-plus"></i>
+								</button>
+							</div>
+						</td>
+						<!-- Col 4, Associated Regression Region -->
 						<td *ngIf="!inGagePage">
 							<div *ngFor="let e of c.regressionRegions; last as isLast">
 								<!-- Col 3, Associated Regression Region (all but the last one) -->

--- a/src/app/shared/components/managecitations/managecitations.component.html
+++ b/src/app/shared/components/managecitations/managecitations.component.html
@@ -50,68 +50,130 @@
 			<table class="custom-table table-striped table-scroll mtop-sm no-scrollbars">
 				<thead>
 					<tr>
-						<th class=citationHeader>Citation</th>
-						<th class=citationEditHeader></th>
+						<th *ngIf="!inGagePage" class=citationHeader>Citation</th>
+						<th *ngIf="!inGagePage" class=citationEditHeader></th>
+						<th *ngIf="inGagePage" class="width-5">ID</th>
+						<th *ngIf="inGagePage" class="width-85">Citation</th>
+						<th *ngIf="inGagePage" class="width-10"></th>
 						<th class=regRegionHeader *ngIf="!inGagePage">Associated Regression Regions</th>
 						<th class="empty-cell regRegionEditHeader" *ngIf="!inGagePage">
 							<!-- Filler button - not used for anything -->
-							<div class="cell-buttons"><button class="icon-button" aria-hidden="true"><i
-										class="far fa-circle"></i></button></div>
+							<div class="cell-buttons"><button class="icon-button" aria-hidden="true"><i class="far fa-circle"></i></button></div>
 						</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr *ngFor="let c of filteredData; let cIndex = index">
-						<!-- Col 1, Citation -->
-						<td class=col1 (click)= "setSelectedCitation(c); d('closed')">
-							<div class="half-space">
-								<span *ngIf="!c.isEditing">{{ c.author }}</span>
-								<span *ngIf="c.isEditing"><textarea class='break' name="author" [(ngModel)]="c.author"
-										required></textarea></span>
-							</div>
-							<div>
-								<span *ngIf="!c.isEditing">{{ c.title }}</span>
-								<span *ngIf="c.isEditing"><textarea class='break' name="title" [(ngModel)]="c.title"
-										required></textarea></span>
-							</div>
-							<div>
-								<a *ngIf="!c.isEditing" [href]="c.citationURL" [target]="_blank">
-									<span *ngIf="!c.isEditing">{{ c.citationURL }}</span>
-								</a>
-								<span *ngIf="c.isEditing"><textarea class='break' name="citationURL"
-										[(ngModel)]="c.citationURL" required></textarea></span>
-							</div>
-						</td>
-						<!-- Col 2 - Citation Buttons -->
-						<td class=editCol>
-							<!-- Editing -->
-							<div [class.hidden]="!showAddCitations" class="cell-buttons">
-								<button *ngIf="!c.isEditing" title="Edit Citation" (click)="editRowClicked(c, cIndex)"
-									class="icon-button" [disabled]="!checkManagerCitations(c)" aria-hidden="true">
-									<i class="far fa-pencil"></i>
-								</button>
-								<button *ngIf="c.isEditing" title="Save Citation" (click)="saveCitation(c)"
-									class="icon-button" aria-hidden="true">
-									<i class="far fa-floppy-o"></i>
-								</button>
-								<button *ngIf="c.isEditing" title="Cancel Edit" (click)="CancelEditRowClicked()"
-									class="icon-button" aria-hidden="true">
-									<i class="far fa-history"></i>
-								</button>
-								<button *ngIf="loggedInRole === 'Administrator' && !c.isEditing" title="Delete Citation"
-									(click)="deleteCitation(c.id)" class="icon-button"
-									[disabled]="c.regressionRegions?.length>0" aria-hidden="true">
-									<i class="far fa-times"></i>
-								</button>
-							</div>
-							<!-- Not editing -->
-							<div [class.hidden]="showAddCitations" class="cell-buttons">
-								<button title="Add Citation" (click)="addExistingCitation(c); d('closed')"
-									class="icon-button" aria-hidden="true">
-									<i class="far fa-plus"></i>
-								</button>
-							</div>
-						</td>
+						<!-- When the Citation Modal is not opened in the GagePage -->
+						<ng-container *ngIf="!inGagePage">	
+							<!-- Col 1, Citation -->
+							<td class=col1>
+								<div class="half-space">
+									<span *ngIf="!c.isEditing">{{ c.author }}</span>
+									<span *ngIf="c.isEditing"><textarea class='break' name="author" [(ngModel)]="c.author"
+											required></textarea></span>
+								</div>
+								<div>
+									<span *ngIf="!c.isEditing">{{ c.title }}</span>
+									<span *ngIf="c.isEditing"><textarea class='break' name="title" [(ngModel)]="c.title"
+											required></textarea></span>
+								</div>
+								<div>
+									<a *ngIf="!c.isEditing" [href]="c.citationURL" [target]="_blank">
+										<span *ngIf="!c.isEditing">{{ c.citationURL }}</span>
+									</a>
+									<span *ngIf="c.isEditing"><textarea class='break' name="citationURL"
+											[(ngModel)]="c.citationURL" required></textarea></span>
+								</div>
+							</td>
+							<!-- Col 2 - Citation Buttons -->
+							<td class=editCol>
+								<!-- Editing -->
+								<div [class.hidden]="!showAddCitations" class="cell-buttons">
+									<button *ngIf="!c.isEditing" title="Edit Citation" (click)="editRowClicked(c, cIndex)"
+										class="icon-button" [disabled]="!checkManagerCitations(c)" aria-hidden="true">
+										<i class="far fa-pencil"></i>
+									</button>
+									<button *ngIf="c.isEditing" title="Save Citation" (click)="saveCitation(c)"
+										class="icon-button" aria-hidden="true">
+										<i class="far fa-floppy-o"></i>
+									</button>
+									<button *ngIf="c.isEditing" title="Cancel Edit" (click)="CancelEditRowClicked()"
+										class="icon-button" aria-hidden="true">
+										<i class="far fa-history"></i>
+									</button>
+									<button *ngIf="loggedInRole === 'Administrator' && !c.isEditing" title="Delete Citation"
+										(click)="deleteCitation(c.id)" class="icon-button"
+										[disabled]="c.regressionRegions?.length>0" aria-hidden="true">
+										<i class="far fa-times"></i>
+									</button>
+								</div>
+								<!-- Not editing -->
+								<div [class.hidden]="showAddCitations" class="cell-buttons">
+									<button title="Add Citation" (click)="addExistingCitation(c); d('closed')"
+										class="icon-button" aria-hidden="true">
+										<i class="far fa-plus"></i>
+									</button>
+								</div>
+							</td>
+						</ng-container>
+						<!-- When the Citation Modal is opened in the GagePage -->
+						<ng-container *ngIf="inGagePage">	
+							<!-- Col 1 -->
+							<td class="width-5">
+								<div >{{c.id}}</div>
+							</td>
+							<!-- Col 2, Citation -->
+							<td class="width-85" (click)= "setSelectedCitation(c); d('closed')">
+								<div class="half-space">
+									<span *ngIf="!c.isEditing">{{ c.author }}</span>
+									<span *ngIf="c.isEditing"><textarea class='break' name="author" [(ngModel)]="c.author"
+											required></textarea></span>
+								</div>
+								<div>
+									<span *ngIf="!c.isEditing">{{ c.title }}</span>
+									<span *ngIf="c.isEditing"><textarea class='break' name="title" [(ngModel)]="c.title"
+											required></textarea></span>
+								</div>
+								<div>
+									<a *ngIf="!c.isEditing" [href]="c.citationURL" [target]="_blank">
+										<span *ngIf="!c.isEditing">{{ c.citationURL }}</span>
+									</a>
+									<span *ngIf="c.isEditing"><textarea class='break' name="citationURL"
+											[(ngModel)]="c.citationURL" required></textarea></span>
+								</div>
+							</td>
+							<!-- Col 2 - Citation Buttons -->
+							<td class="width-10">
+								<!-- Editing -->
+								<div [class.hidden]="!showAddCitations" class="cell-buttons">
+									<button *ngIf="!c.isEditing" title="Edit Citation" (click)="editRowClicked(c, cIndex)"
+										class="icon-button" [disabled]="!checkManagerCitations(c)" aria-hidden="true">
+										<i class="far fa-pencil"></i>
+									</button>
+									<button *ngIf="c.isEditing" title="Save Citation" (click)="saveCitation(c)"
+										class="icon-button" aria-hidden="true">
+										<i class="far fa-floppy-o"></i>
+									</button>
+									<button *ngIf="c.isEditing" title="Cancel Edit" (click)="CancelEditRowClicked()"
+										class="icon-button" aria-hidden="true">
+										<i class="far fa-history"></i>
+									</button>
+									<button *ngIf="loggedInRole === 'Administrator' && !c.isEditing" title="Delete Citation"
+										(click)="deleteCitation(c.id)" class="icon-button"
+										[disabled]="c.regressionRegions?.length>0" aria-hidden="true">
+										<i class="far fa-times"></i>
+									</button>
+								</div>
+								<!-- Not editing -->
+								<div [class.hidden]="showAddCitations" class="cell-buttons">
+									<button title="Add Citation" (click)="addExistingCitation(c); d('closed')"
+										class="icon-button" aria-hidden="true">
+										<i class="far fa-plus"></i>
+									</button>
+								</div>
+							</td>
+						</ng-container>
 						<!-- Col 3, Associated Regression Region -->
 						<td *ngIf="!inGagePage">
 							<div *ngFor="let e of c.regressionRegions; last as isLast">

--- a/src/app/shared/components/managecitations/managecitations.component.scss
+++ b/src/app/shared/components/managecitations/managecitations.component.scss
@@ -60,16 +60,8 @@ button {
 
 .col1 {
     width: 450px;
-
-    &.inGagePage{
-        width: 90%;
-    }
 }
 
 .editCol {
     width: 41px;
-
-    &.inGagePage{
-        width: 10%;
-    }
 }

--- a/src/app/shared/components/managecitations/managecitations.component.scss
+++ b/src/app/shared/components/managecitations/managecitations.component.scss
@@ -65,3 +65,7 @@ button {
 .editCol {
     width: 41px;
 }
+
+.selectedRow {
+    background-color: rgb(218, 110, 110) !important;
+}

--- a/src/app/shared/components/managecitations/managecitations.component.scss
+++ b/src/app/shared/components/managecitations/managecitations.component.scss
@@ -24,13 +24,13 @@ button {
 }
 
 .editRegRegion {
-    width:45px; 
+    width: 45px; 
     border-top-style:none; 
     border-right-style: none;
 }
 
 .editRegRegionLast {
-    width:45px; 
+    width: 45px; 
     border-top-style:none; 
     border-right-style: none; 
     border-bottom-style:none;
@@ -60,8 +60,16 @@ button {
 
 .col1 {
     width: 450px;
+
+    &.inGagePage{
+        width: 90%;
+    }
 }
 
 .editCol {
     width: 41px;
+
+    &.inGagePage{
+        width: 10%;
+    }
 }

--- a/src/app/shared/components/managecitations/managecitations.component.ts
+++ b/src/app/shared/components/managecitations/managecitations.component.ts
@@ -56,6 +56,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     public inGageStats: boolean = false;
     //public selectCitation: {id: 1};
     public selectedRow: number;
+    public url;
 
     public tempSelectedStatisticGrp: Array<Statisticgroup>;
     public get selectedStatisticGrp(): Array<Statisticgroup> {
@@ -121,6 +122,17 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
         // Subscribe to server with '?bycitation=true'
         // Copy settingservice getEntities on regions.component.ts file
     }  // End OnInit
+
+    public setURL() {
+        if (this.inGagePage) {
+            this.url = this.configSettings.gageStatsBaseURL + this.configSettings.citationURL
+        }
+        else {
+            this.url = this.configSettings.nssBaseURL + this.configSettings.citationURL
+        }    
+        console.log(this.url)
+
+    }
 
     public saveFilters(){
         this.tempSelectedStatisticGrp = this.selectedStatisticGrp;
@@ -201,7 +213,8 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
 
     public saveCitation(c) {
         // put edited scenario
-        this._settingsService.putEntity(c.id, c, this.configSettings.gageStatsBaseURL + this.configSettings.citationURL)
+        this.setURL();
+        this._settingsService.putEntity(c.id, c, this.url)
             .subscribe((response) => {
                 c.isEditing = false;
                 this._nssService.setSelectedRegion(this.selectedRegion); // update everything
@@ -220,7 +233,8 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     public createNewCitation(){
         this.saveFilters();
           // add new citation
-        this._settingsService.postEntity(this.newCitForm.value, this.configSettings.gageStatsBaseURL + this.configSettings.citationURL)
+        this.setURL();
+        this._settingsService.postEntity(this.newCitForm.value, this.url)
         .subscribe((response: any) => {
             this.newCitForm.reset();
             this.showNewCitation = false;
@@ -265,12 +279,8 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
         const header: HttpHeaders = new HttpHeaders({
             'Content-Type': 'application/json',
         });
-        if (this.inGagePage == true) {
-            var url = this.configSettings.gageStatsBaseURL+this.configSettings.citationURL;
-        } else {
-            url = this.configSettings.nssBaseURL+this.configSettings.citationURL;
-        }
-        this._http.get(url, { headers: header, observe: "response"})
+        this.setURL();
+        this._http.get(this.url, { headers: header, observe: "response"})
             .subscribe(res => {
                 this.citations = res.body;
                 this.filteredData = this.citations.filter(function (filter) {
@@ -323,8 +333,9 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
 
     public deleteCitation(id) {
         const check = confirm('Are you sure you want to delete this citation?');
+        this.setURL();
         if (check) {
-            this._settingsService.deleteEntity(id, this.configSettings.nssBaseURL + this.configSettings.citationURL).subscribe(result => {
+            this._settingsService.deleteEntity(id, this.url).subscribe(result => {
                 this._nssService.setSelectedRegion(this.selectedRegion);
                 if (result.headers) { this._nssService.outputWimMessages(result); }
             }, error => {

--- a/src/app/shared/components/managecitations/managecitations.component.ts
+++ b/src/app/shared/components/managecitations/managecitations.component.ts
@@ -52,6 +52,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     public newCitForm: FormGroup;
     public regions: Array<Region>;
     public managerRegressionRegions: any[] = [];
+    public inGagePage: boolean;
 
     public tempSelectedStatisticGrp: Array<Statisticgroup>;
     public get selectedStatisticGrp(): Array<Statisticgroup> {
@@ -110,6 +111,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
         this.modalSubscript = this._nssService.showManageCitationsModal.subscribe((result: ManageCitation) => {
             if (result.show) { 
                 this.showAddCitations = result.addCitation;
+                this.inGagePage = result.inGagePage;
               }
           });
         this.modalElement = this.manageCitationsModal;
@@ -216,6 +218,12 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
             if (this._settingsService.outputWimMessages(error)) { return; }
             this._toasterService.pop('error', 'Error creating Citation', error.message || error._body.message || error.statusText);
         });
+    }
+
+    public setSelectedCitation(c) {
+        if(this.inGagePage) {
+            this._nssService.setSelectedCitation(c);
+        }
     }
 
     outputWimMessages(msg) {

--- a/src/app/shared/components/managecitations/managecitations.component.ts
+++ b/src/app/shared/components/managecitations/managecitations.component.ts
@@ -38,7 +38,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     private configSettings: Config;
     public modalRef;
     public loggedInRole;
-    public citations = [];
+    public citations;
     public tempCitations;
     public scenarios: Scenario[];
     public filteredData;
@@ -99,7 +99,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
                 this.showAddCitations = result.addCitation;
                 this.inGagePage = result.inGagePage;
                 this.inGageStats = result.inGageStats
-                this.citations;
+                this.getCitations();
                 this.selectedRow = result.selectCitation;
                 this.showModal(); 
                 this.filterText = "";
@@ -145,12 +145,15 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
         } 
         //Citations from GSS
         if (this.inGagePage) {
-            this.filteredData = this.citations.filter(c => 
-                c != null &&
-                (c.author.toLowerCase().includes(input.toLowerCase()) ||
-                c.title.toLowerCase().includes(input.toLowerCase()) ));
-            } 
-            
+            if (this.citations == null) {
+                return
+            } else { 
+                this.filteredData = this.citations.filter(c => 
+                    c != null &&
+                    (c.author.toLowerCase().includes(input.toLowerCase()) ||
+                    c.title.toLowerCase().includes(input.toLowerCase()) ));
+                } 
+            }
     }
 
     public getRegRegions() {

--- a/src/app/shared/components/managecitations/managecitations.component.ts
+++ b/src/app/shared/components/managecitations/managecitations.component.ts
@@ -157,8 +157,8 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     }
 
     public getRegRegions() {
-        // moving to own function for when new regression region is added
-        this._settingsService.getEntities(this.configSettings.regionURL + this.selectedRegion.id + '/' + this.configSettings.regRegionURL)
+        // moving to own function for when new regression region is added, get RegRegions from NSS
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + this.selectedRegion.id + '/' + this.configSettings.regRegionURL)
             .subscribe(res => {
             if (res.length > 1) { res.sort((a, b) => a.name.localeCompare(b.name)); }
             this.regressionRegions = res;
@@ -201,7 +201,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
 
     public saveCitation(c) {
         // put edited scenario
-        this._settingsService.putEntity(c.id, c, this.configSettings.citationURL)
+        this._settingsService.putEntity(c.id, c, this.configSettings.gageStatsBaseURL + this.configSettings.citationURL)
             .subscribe((response) => {
                 c.isEditing = false;
                 this._nssService.setSelectedRegion(this.selectedRegion); // update everything
@@ -220,7 +220,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     public createNewCitation(){
         this.saveFilters();
           // add new citation
-        this._settingsService.postEntity(this.newCitForm.value, this.configSettings.citationURL)
+        this._settingsService.postEntity(this.newCitForm.value, this.configSettings.gageStatsBaseURL + this.configSettings.citationURL)
         .subscribe((response: any) => {
             this.newCitForm.reset();
             this.showNewCitation = false;
@@ -305,7 +305,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     }
 
     public getManagerCitations() {
-        this._settingsService.getEntities(this.configSettings.citationURL)
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.citationURL)
         .subscribe(res => {
            this.managerCitations = res.filter(item => item !== null);
         });
@@ -314,7 +314,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     public getManagerRegressionRegions(){
         this.managerRegressionRegions = [];
         this.regions.forEach(r => {
-            this._settingsService.getEntities(this.configSettings.regionURL + r.id + '/' + this.configSettings.regRegionURL)
+            this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + r.id + '/' + this.configSettings.regRegionURL)
             .subscribe(res => {
                 this.managerRegressionRegions.push(res);
             });
@@ -324,7 +324,7 @@ export class ManageCitationsModal implements OnInit, OnDestroy {
     public deleteCitation(id) {
         const check = confirm('Are you sure you want to delete this citation?');
         if (check) {
-            this._settingsService.deleteEntity(id, this.configSettings.citationURL).subscribe(result => {
+            this._settingsService.deleteEntity(id, this.configSettings.nssBaseURL + this.configSettings.citationURL).subscribe(result => {
                 this._nssService.setSelectedRegion(this.selectedRegion);
                 if (result.headers) { this._nssService.outputWimMessages(result); }
             }, error => {

--- a/src/app/shared/components/profile/profile.component.ts
+++ b/src/app/shared/components/profile/profile.component.ts
@@ -64,7 +64,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
             this._toasterService.pop(this.toast);
         });
         this.getLoggedInID();
-        this._settingsService.getEntities(this.configSettings.rolesURL).subscribe(roles => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.rolesURL).subscribe(roles => {
             this.roles = roles;
             this.getUserInfo();
         });
@@ -77,7 +77,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
     }
 
     private getUserInfo() {
-        this._settingsService.getEntities(this.configSettings.managersURL + '/' + this.loggedInID).subscribe(res => {
+        this._settingsService.getEntities(this.configSettings.nssBaseURL + this.configSettings.managersURL + '/' + this.loggedInID).subscribe(res => {
             this.userInfo = res;
         });
     }
@@ -102,7 +102,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
         } else {
             delete this.userInfo.isEditing;
             delete this.userInfo.role;
-            this._settingsService.putEntity(this.userInfo.id, this.userInfo, this.configSettings.managersURL).subscribe(
+            this._settingsService.putEntity(this.userInfo.id, this.userInfo, this.configSettings.nssBaseURL + this.configSettings.managersURL).subscribe(
                 (resp) => {
                     this.userInfo.isEditing = false;
                     this.getUserInfo();

--- a/src/app/shared/interfaces/managecitations.ts
+++ b/src/app/shared/interfaces/managecitations.ts
@@ -2,4 +2,6 @@ export interface ManageCitation {
     show:true,
     addCitation: boolean
     inGagePage?: boolean
+    inGageStats?: boolean
+    selectCitation?: number
 }

--- a/src/app/shared/interfaces/managecitations.ts
+++ b/src/app/shared/interfaces/managecitations.ts
@@ -1,4 +1,5 @@
 export interface ManageCitation {
     show:true,
     addCitation: boolean
+    inGagePage?: boolean
 }

--- a/src/app/shared/interfaces/station.ts
+++ b/src/app/shared/interfaces/station.ts
@@ -1,6 +1,7 @@
 import { Citation } from './citation';
 import { GageCharacteristic } from './gagecharacteristic';
 import { GageStatistic } from './gagestatistic';
+import { Region } from './region';
 
 export interface Station {
     agencyID: string;
@@ -13,4 +14,5 @@ export interface Station {
     characteristics: Array<GageCharacteristic>;
     statistics: Array<GageStatistic>;
     citations: Array<Citation>;
+    region?: any;
 }

--- a/src/app/shared/services/app.service.ts
+++ b/src/app/shared/services/app.service.ts
@@ -711,7 +711,7 @@ export class NSSService {
             url += params; 
         }
         return this._http
-            .get(this.configSettings.nssBaseURL + this.configSettings.regionURL + id + '/' + url, { headers: this.jsonHeader })
+            .get(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + id + '/' + url, { headers: this.jsonHeader })
             .map(res => <Array<Regressionregion>>res);
     }
 
@@ -722,7 +722,7 @@ export class NSSService {
             url += params; 
         }
         return this._http
-            .get(this.configSettings.nssBaseURL + this.configSettings.regionURL + id + '/' + url, { headers: this.jsonHeader })
+            .get(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + id + '/' + url, { headers: this.jsonHeader })
             .map(res => <Regressiontype[]>res);
     }
 
@@ -733,7 +733,7 @@ export class NSSService {
             url += params; 
         }
         return this._http
-            .get(this.configSettings.nssBaseURL + this.configSettings.regionURL + id + '/' + url, { headers: this.jsonHeader })
+            .get(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + id + '/' + url, { headers: this.jsonHeader })
             .map(res => <Statisticgroup[]>res);
     }
 
@@ -744,7 +744,7 @@ export class NSSService {
             url += params; 
         }
         return this._http
-            .get(this.configSettings.nssBaseURL + this.configSettings.regionURL + id + '/' + url, { headers: this.jsonHeader })
+            .get(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + id + '/' + url, { headers: this.jsonHeader })
             .map(res => <Scenario[]>res)
             .subscribe(
                 s => {
@@ -781,7 +781,7 @@ export class NSSService {
     postScenarios(id: number, s: Scenario[], searchArgs?: string) {
         const options = { headers: this.jsonHeader, observe: 'response' as 'response' };      
         return this._http
-            .post(this.configSettings.nssBaseURL + this.configSettings.regionURL + id + '/scenarios/estimate/' + searchArgs, s, options)
+            .post(this.configSettings.nssBaseURL + this.configSettings.regionURL + '/' + id + '/scenarios/estimate/' + searchArgs, s, options)
             // .map(sResult => sResult.json())
             .subscribe(
                 res => {

--- a/src/app/shared/services/app.service.ts
+++ b/src/app/shared/services/app.service.ts
@@ -129,7 +129,7 @@ export class NSSService {
     public setManageCitationsModal(val: ManageCitation) { 
         this._showHideManageCitationsModal.next(val);
     }
-    // show the manage citations modal in the mainview
+    // show the manage citations modal 
     public get showManageCitationsModal(): any {
         return this._showHideManageCitationsModal.asObservable();
     }
@@ -139,6 +139,15 @@ export class NSSService {
     addExistingCitation(item: any){
         this.citationSource.next(item);
     }
+    // set selected citation
+    private _selectedCitation: Subject<Citation> = new Subject<Citation>();
+    public setSelectedCitation(val: Citation) {
+        this._selectedCitation.next(val);
+    }
+    public get selectedCitation(): Observable<Citation> {
+        return this._selectedCitation.asObservable();
+    }
+
     // -+-+-+-+-+-+-+-+-+ add regression region modal -+-+-+-+-+-+-+-+
     private _showHideAddRegressioRegionModal: Subject<AddRegressionRegion> = new Subject<AddRegressionRegion>();
     public setAddRegressionRegionModal(val: AddRegressionRegion) {

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -7,7 +7,7 @@
     "errorsURL": "Errors",
     "loginURL": "authenticate",
     "managersURL": "Managers",
-    "regionURL": "Regions/",
+    "regionURL": "Regions",
     "regRegionURL": "RegressionRegions",
     "regTypeURL": "RegressionTypes",
     "rolesURL": "Roles",


### PR DESCRIPTION
Added the Citation Modal to the GagePage so that it can be used to select the citations for new chars/stats and for editing chars/stats. Also made it so that only a single newchar/newstat/char/stat/GageInfo can be edited at a time. Made edits to the Citation Modal when it is opened in the GagePage: added an ID column and removed the last two columns.