### PR TITLE
Fixes #388

### DIFF
--- a/src/app/settings/categories/statisticgroups/statisticgroups.component.html
+++ b/src/app/settings/categories/statisticgroups/statisticgroups.component.html
@@ -19,8 +19,9 @@
             <thead>
                 <tr>
                     <th class="width-5"></th>
-                    <th class="width-60">Name</th>
-                    <th class="width-35">Code</th>
+                    <th class="width-50">Name</th>
+                    <th class="width-25">Code</th>
+                    <th class="width-20">Def Type</th>
                 </tr>
             </thead>
             <tbody>
@@ -46,6 +47,14 @@
                     <td>
                         <span *ngIf="!r.isEditing">{{ r.code }}</span>
                         <span *ngIf="r.isEditing"><input type="text" name="code" [(ngModel)]="r.code" required/></span>
+                    </td>
+                    <td>
+                        <span *ngIf="!r.isEditing">{{ r.defType }}</span>
+                        <span *ngIf="r.isEditing">
+                            <ng-select  bindLabel="defType" [(ngModel)]="r.defType" name="defType" [selectOnTab]="true" [closeOnSelect]="true" [clearable]="false" >
+                                <ng-option *ngFor="let dt of defTypes" [value]="dt.code">{{dt.code}} ({{dt.name}})</ng-option>
+                            </ng-select>
+                        </span>
                     </td>
                 </tr>
             </tbody>
@@ -83,6 +92,20 @@
                 <input class="form-control" type="text" formControlName="code" />
                 <div class="input-invalid-warning" *ngIf="!newStatGroupForm.get('code').valid && newStatGroupForm.get('code').dirty">
                     Code is required
+                </div>
+            </div>
+
+            <!-- Def Type -->
+            <div
+                class="form-group required"
+                [ngClass]="{ 'form-invalid': !newStatGroupForm.get('defType').valid && newStatGroupForm.get('defType').dirty }"
+            >
+                <label class="req" for="defType">Def Type:</label>
+                <ng-select formControlName="defType"  [selectOnTab]="true" [closeOnSelect]="true" [clearable]="false" >
+                    <ng-option *ngFor="let dt of defTypes" [value]="dt.code">{{dt.code}} ({{dt.name}})</ng-option>
+                </ng-select>
+                <div class="input-invalid-warning" *ngIf="!newStatGroupForm.get('defType').valid && newStatGroupForm.get('defType').dirty">
+                    Def Type is required
                 </div>
             </div>
         </form>

--- a/src/app/settings/categories/statisticgroups/statisticgroups.component.ts
+++ b/src/app/settings/categories/statisticgroups/statisticgroups.component.ts
@@ -13,7 +13,6 @@ import { ToasterService } from 'angular2-toaster/angular2-toaster';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
 
 import { NSSService } from 'app/shared/services/app.service';
-import { Region } from 'app/shared/interfaces/region';
 import { Statisticgroup } from 'app/shared/interfaces/statisticgroup';
 import { SettingsService } from '../../settings.service';
 
@@ -31,7 +30,6 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
     @ViewChild('add', {static: true})
     public addRef: TemplateRef<any>;
     @ViewChild('StatGroupForm', {static: true}) statGroupForm;
-    public regressionTypes;
     public selectedRegion;
     public regions;
     public selectedRegRegionIDs;
@@ -44,18 +42,19 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
     private navigationSubscription;
     public loggedInRole;
     private configSettings: Config;
-    public allStatGroups: Array<Statisticgroup>;
     public rowBeingEdited: number;
     public tempData;
     public isEditing = false;
     public modalRef;
+    public defTypes = [{"code":"FS", "name": "Flow Statistics"}, {"code":"BC", "name": "Basin Characteristics"}];
 
     constructor(public _nssService: NSSService, public _settingsservice: SettingsService, public _route: ActivatedRoute,
         private _fb: FormBuilder, private _modalService: NgbModal, private router: Router,
         private _toasterService: ToasterService, private _configService: ConfigService) {
             this.newStatGroupForm = _fb.group({
                 'name': new FormControl(null, Validators.required),
-                'code': new FormControl(null, Validators.required)
+                'code': new FormControl(null, Validators.required),
+                'defType': new FormControl(null, Validators.required)
             });
             this.navigationSubscription = this.router.events.subscribe((e: any) => {
                 if (e instanceof NavigationEnd) {
@@ -71,14 +70,10 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
         });
         this.selectedRegion = 'none';
         this.getAllStatGroups();
-
-        this._settingsservice.statisticGroups().subscribe(sg => {
-            this.statisticGroups = sg;
-        });
     }
+
     public getAllStatGroups() {
         this._settingsservice.getEntities(this.configSettings.nssBaseURL + this.configSettings.statisticGrpURL).subscribe(res => {
-            this.allStatGroups = res;
             if (this.selectedRegion === 'none') {this.statisticGroups = res; }
         });
     }
@@ -100,6 +95,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
     public showNewStatGroupForm() {
         this.newStatGroupForm.controls['name'].setValue(null);
         this.newStatGroupForm.controls['code'].setValue(null);
+        this.newStatGroupForm.controls['defType'].setValue(null);
         this.showNewStatForm = true;
         this.modalRef = this._modalService.open(this.addRef, { backdrop: 'static', keyboard: false, size: 'lg' });
         this.modalRef.result.then((result) => {
@@ -154,7 +150,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
         this.tempData = Object.assign({}, this.statisticGroups[i]); 
         this.rowBeingEdited = i;
         this.isEditing = true; // set to true so create new is disabled
-}
+    }
 
     public CancelEditRowClicked(i: number) {
         this.statisticGroups[i] = Object.assign({}, this.tempData);
@@ -185,7 +181,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
                 }, error => {
                     if (this._settingsservice.outputWimMessages(error)) {return; }
                     this._toasterService.pop('error', 'Error updating Statistic Group', error._body.message || error.statusText);
-            }
+                }
             );
         }
     }
@@ -204,7 +200,7 @@ export class StatisticGroupsComponent implements OnInit, OnDestroy {
                 }, error => {
                     if (this._settingsservice.outputWimMessages(error)) {return; }
                     this._toasterService.pop('error', 'Error deleting Statistic Group', error._body.message || error.statusText);
-            }
+                }
             );
         }
     }


### PR DESCRIPTION
Displays the DefType in the Statistic Groups Table in the Settings page
Allows assigning of the deftype when creating a new statistic group
Allows editing of the deftype when editing a statistic group

Removed unused import
Removed unused variables (`regressionTypes `and `allStatGroups`)