### PR TITLE
Fixes #405

### DIFF
--- a/src/app/gagestats/add-station/add-station.component.ts
+++ b/src/app/gagestats/add-station/add-station.component.ts
@@ -105,6 +105,7 @@ export class AddStationModal implements OnInit {
         }
         this.cancelSubmitStation();
         this._nssService.searchStations(this.selectedParams);
+        this._nssService.setRequryGSFilter(true);
       }, error => {
         if (!this._settingsService.outputWimMessages(error)) {
           this._toasterService.pop('error', 'Error adding Station', error.message || error.statusText);

--- a/src/app/gagestats/add-station/add-station.component.ts
+++ b/src/app/gagestats/add-station/add-station.component.ts
@@ -105,7 +105,7 @@ export class AddStationModal implements OnInit {
         }
         this.cancelSubmitStation();
         this._nssService.searchStations(this.selectedParams);
-        this._nssService.setRequryGSFilter(true);
+        this._nssService.setRequeryGSFilter(true);
       }, error => {
         if (!this._settingsService.outputWimMessages(error)) {
           this._toasterService.pop('error', 'Error adding Station', error.message || error.statusText);

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -57,6 +57,17 @@
 							</td>
 						</tr>
 						<tr>
+							<td>Region</td>
+							<td>
+								<span *ngIf="!editGageInfo">{{gage.region.name}}</span>
+								<span *ngIf="editGageInfo">
+									<ng-select name="region" [(ngModel)]="gage.regionID" [clearable]="false">
+										<ng-option *ngFor="let r of regions" [value]="r.id">{{r.name}}</ng-option>
+									</ng-select>
+								</span>
+							</td>
+						</tr>
+						<tr>
 							<td>Station Type</td>
 							<td>
 								<span *ngIf="!editGageInfo">{{gage.stationType.name}}</span>

--- a/src/app/gagestats/gagepage/gagepage.component.html
+++ b/src/app/gagestats/gagepage/gagepage.component.html
@@ -57,7 +57,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td>Region</td>
+							<td>Study Area</td>
 							<td>
 								<span *ngIf="!editGageInfo">{{gage.region.name}}</span>
 								<span *ngIf="editGageInfo">

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -17,6 +17,7 @@ import { Agency } from 'app/shared/interfaces/agency';
 import { Stationtype } from 'app/shared/interfaces/stationtype';
 import { HttpParams } from '@angular/common/http';
 import { LoaderService } from 'app/shared/services/loader.service';
+import { Region } from 'app/shared/interfaces/region';
 
 @Component({
   selector: 'gagePageModal',
@@ -64,6 +65,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
   public agencies: Agency[];
   public stationTypes: Stationtype[];
   public selectedParams: HttpParams;
+  public regions: Region[];
 
   constructor(
     private _nssService: NSSService, 
@@ -135,6 +137,10 @@ export class GagepageComponent implements OnInit, OnDestroy {
     this._nssService.getAgencies();
     this._nssService.agencies.subscribe((ag: Array<Agency>) => {
       this.agencies = ag;
+    });
+    // get all regions
+    this._nssService.regions.subscribe((regionList: Array<Region>) => {
+      this.regions = regionList;
     });
     // get all station types
     this._nssService.getStationTypes();
@@ -247,7 +253,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
             this._nssService.outputWimMessages(result); 
             this.modalRef.close();    
             this._nssService.searchStations(this.selectedParams);
-            
+            this._nssService.setRequryGSFilter(true);
           }
       }, error => {
           if (error.headers) {this._nssService.outputWimMessages(error);
@@ -258,7 +264,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
 
   public saveGageInfo(gage){
     const newItem = JSON.parse(JSON.stringify(gage)); 
-    ['agency', 'stationType', 'statistics', 'characteristics'].forEach(e => delete newItem[e]);  
+    ['agency', 'stationType', 'region', 'statistics', 'characteristics'].forEach(e => delete newItem[e]);  
       this._settingsservice.putEntity(newItem.id, newItem, this.configSettings.gageStatsBaseURL + this.configSettings.stationsURL).subscribe(
         (res) => {
           this.editGageInfo = false;
@@ -474,6 +480,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
         return a.statisticGroupTypeID - b.statisticGroupTypeID;
       });
       this.gage = res;
+      this._nssService.setRequryGSFilter(true);
       this.getCitations();
       this.getDisplayStatGroupID(this.gage);
       this.filterStatIds();

--- a/src/app/gagestats/gagepage/gagepage.component.ts
+++ b/src/app/gagestats/gagepage/gagepage.component.ts
@@ -253,7 +253,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
             this._nssService.outputWimMessages(result); 
             this.modalRef.close();    
             this._nssService.searchStations(this.selectedParams);
-            this._nssService.setRequryGSFilter(true);
+            this._nssService.setRequeryGSFilter(true);
           }
       }, error => {
           if (error.headers) {this._nssService.outputWimMessages(error);
@@ -480,7 +480,7 @@ export class GagepageComponent implements OnInit, OnDestroy {
         return a.statisticGroupTypeID - b.statisticGroupTypeID;
       });
       this.gage = res;
-      this._nssService.setRequryGSFilter(true);
+      this._nssService.setRequeryGSFilter(true);
       this.getCitations();
       this.getDisplayStatGroupID(this.gage);
       this.filterStatIds();

--- a/src/app/gagestats/gs-sidebar/gs-sidebar.component.ts
+++ b/src/app/gagestats/gs-sidebar/gs-sidebar.component.ts
@@ -45,7 +45,7 @@ export class GsSidebarComponent implements OnInit {
   }
 
   ngOnInit() {
-    this._nssService.requryGSFilter.subscribe((bool:boolean)=>{
+    this._nssService.requeryGSFilter.subscribe((bool:boolean)=>{
       this.requeryFilter = bool;
       if (this.requeryFilter = true){
         this.onSearch();

--- a/src/app/gagestats/gs-sidebar/gs-sidebar.component.ts
+++ b/src/app/gagestats/gs-sidebar/gs-sidebar.component.ts
@@ -38,12 +38,19 @@ export class GsSidebarComponent implements OnInit {
   public keyword = "";
   public timeout: any = null;
   public loadCount = 0;
+  public requeryFilter: boolean;
 
   constructor(private _nssService: NSSService, public _settingsservice: SettingsService, private _configService: ConfigService) {
     this.configSettings = this._configService.getConfiguration();
   }
 
   ngOnInit() {
+    this._nssService.requryGSFilter.subscribe((bool:boolean)=>{
+      this.requeryFilter = bool;
+      if (this.requeryFilter = true){
+        this.onSearch();
+      }
+    });
     this._nssService.selectedPageNumber.subscribe((page: string) => {
       if (page == " ") {
         page = '1';
@@ -145,6 +152,7 @@ export class GsSidebarComponent implements OnInit {
         this.variableTypes = vt;
       });
 
+      this.requeryFilter = false;
       this._nssService.setSelectedFilterParams(this.params);
       this._nssService.searchStations(this.params);
     }

--- a/src/app/shared/interfaces/station.ts
+++ b/src/app/shared/interfaces/station.ts
@@ -1,7 +1,6 @@
 import { Citation } from './citation';
 import { GageCharacteristic } from './gagecharacteristic';
 import { GageStatistic } from './gagestatistic';
-import { Region } from './region';
 
 export interface Station {
     agencyID: string;
@@ -14,5 +13,5 @@ export interface Station {
     characteristics: Array<GageCharacteristic>;
     statistics: Array<GageStatistic>;
     citations: Array<Citation>;
-    region?: any;
+    regionID: string;
 }

--- a/src/app/shared/services/app.service.ts
+++ b/src/app/shared/services/app.service.ts
@@ -277,11 +277,11 @@ export class NSSService {
      }
 
     // Requery Filters
-    private requry = new BehaviorSubject<boolean>(false);
-    requryGSFilter = this.requry.asObservable();
+    private requery = new BehaviorSubject<boolean>(false);
+    requeryGSFilter = this.requery.asObservable();
 
-    setRequryGSFilter(bool: boolean){
-        this.requry.next(bool);
+    setRequeryGSFilter(bool: boolean){
+        this.requery.next(bool);
     }
     // -+-+-+-+-+-+ end gage stats filter section -+-+-+-+-+-+-+
 

--- a/src/app/shared/services/app.service.ts
+++ b/src/app/shared/services/app.service.ts
@@ -275,6 +275,14 @@ export class NSSService {
      public setSelectedFilterParams(params: HttpParams) {
          this._selectedFilterParams.next(params);
      }
+
+    // Requery Filters
+    private requry = new BehaviorSubject<boolean>(false);
+    requryGSFilter = this.requry.asObservable();
+
+    setRequryGSFilter(bool: boolean){
+        this.requry.next(bool);
+    }
     // -+-+-+-+-+-+ end gage stats filter section -+-+-+-+-+-+-+
 
     // -+-+-+-+-+-+ pages section -+-+-+-+-+-+


### PR DESCRIPTION
Able to view and edit region in gage page.

I noticed when editing the region on gages that sometimes you are changing the region for only gage with that certain region (or station type, agency, ect) which in turn makes the sidebar dropdowns incorrect. Therefor, I added code to requery the GageStats sidebar when a gage is edited, deleted, or added.
