### PR TITLE
Fixes #416

### DIFF
--- a/src/app/gagestats/gs-sidebar/gs-sidebar.component.html
+++ b/src/app/gagestats/gs-sidebar/gs-sidebar.component.html
@@ -34,7 +34,7 @@
     </div>
 
     <div class="sidebar-item">
-        <label>Limit by Regression Types:</label>
+        <label>Limit by Statistic Variables:</label>
         <ss-multiselect-dropdown [options]="regressionTypes" [texts]="myMSTexts" [settings]="myRTSettings"
         [(ngModel)]="selectedRegressionTypes" (ngModelChange)="onSearch()" name="regressionTypes">
         </ss-multiselect-dropdown>

--- a/src/app/gagestats/gs-sidebar/gs-sidebar.component.html
+++ b/src/app/gagestats/gs-sidebar/gs-sidebar.component.html
@@ -41,7 +41,7 @@
     </div>
 
     <div class="sidebar-item">
-        <label>Limit by Variable Types:</label>
+        <label>Limit by Characteristic Variables:</label>
         <ss-multiselect-dropdown [options]="variableTypes" [texts]="myMSTexts" [settings]="myRTSettings"
         [(ngModel)]="selectedVariableTypes" (ngModelChange)="onSearch()" name="variableTypes">
         </ss-multiselect-dropdown>


### PR DESCRIPTION
In the GageStats side bar "Limit by Regression Type" replaced with “Limit by Statistic Variable”

