### PR TITLE
Fixes #422

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,17 @@ Clone the repo and navigate to folder.
 
 ## Building and testing
 
+To compile the project for a production environment run:
 ```
 ng build --prod --base-href
 ```
+
+To compile the project for a non-production environment run:
+```
+ng build --base-href
+```
+
+The `--prod` tag will use the production configuration and point to the production services.
 
 ## Deployment
 

--- a/src/assets/prodConfig.json
+++ b/src/assets/prodConfig.json
@@ -21,7 +21,7 @@
      "variablesURL": "Variables",
      "statusURL": "Status",
      "methodURL": "Methods",
-     "loginShow": true,
-     "showGageStats": true
+     "loginShow": false,
+     "showGageStats": false
  }
  

--- a/src/assets/prodConfig.json
+++ b/src/assets/prodConfig.json
@@ -1,0 +1,27 @@
+{
+    "nssBaseURL": "https://streamstats.usgs.gov/nssservices/",
+    "gageStatsBaseURL": "https://streamstats.usgs.gov/gagestatsservices/",
+     "agenciesURL": "Agencies",
+     "characteristicsURL": "Characteristics",
+     "citationURL": "Citations",
+     "errorsURL": "Errors",
+     "loginURL": "authenticate",
+     "managersURL": "Managers",
+     "regionURL": "Regions",
+     "regRegionURL": "RegressionRegions",
+     "regTypeURL": "RegressionTypes",
+     "rolesURL": "Roles",
+     "scenariosURL": "Scenarios",
+     "stationsURL": "Stations",
+     "statisticsURL": "Statistics",
+     "stationTypeURL": "StationTypes",
+     "statisticGrpURL": "StatisticGroups",
+     "unitsURL": "Units",
+     "unitSystemsURL": "UnitSystems",
+     "variablesURL": "Variables",
+     "statusURL": "Status",
+     "methodURL": "Methods",
+     "loginShow": true,
+     "showGageStats": true
+ }
+ 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  configFile: 'assets/config.json',
+  configFile: 'assets/prodConfig.json',
   version: require('../../package.json').version
 };


### PR DESCRIPTION
I _think_ this will work, but I wasn't sure how to test. From my understanding when you run ng build for production it will replace `src/environments/environment.ts` with `src/environments/environment.prod.ts`, which in turn should call the newly created `assets/prodConfig.json` that has the correct service endpoints for production. I could have been way off with my thinking though, so let me know if this won't work.