### PR TITLE
Fixes #417 - Limit by Regulation Status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4424,7 +4424,6 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4620,8 +4619,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4711,8 +4709,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/app/gagestats/gs-sidebar/gs-sidebar.component.html
+++ b/src/app/gagestats/gs-sidebar/gs-sidebar.component.html
@@ -46,9 +46,16 @@
         [(ngModel)]="selectedVariableTypes" (ngModelChange)="onSearch()" name="variableTypes">
         </ss-multiselect-dropdown>
     </div>
+    
+    <div class="sidebar-item">
+        <label>Limit by Regulation Status:</label>
+        <ss-multiselect-dropdown [options]="regulationStatuses" [texts]="myMSTexts" [settings]="myRTSettings"
+        [(ngModel)]="selectedRegulationStatuses" (ngModelChange)="onSearch()" name="regulationStatuses">
+        </ss-multiselect-dropdown>
+    </div>
 
     <!-- Fix This -->
-    <div class="sidebar-item center" *ngIf="keyword!='' || selectedAgencies.length > 0 || selectedRegions.length > 0 || selectedStationTypes.length > 0 || selectedStatisticGroups.length > 0 || selectedRegressionTypes.length > 0 || selectedVariableTypes.length > 0" >
+    <div class="sidebar-item center" *ngIf="keyword!='' || selectedAgencies.length > 0 || selectedRegions.length > 0 || selectedStationTypes.length > 0 || selectedStatisticGroups.length > 0 || selectedRegressionTypes.length > 0 || selectedVariableTypes.length > 0 || selectedRegulationStatuses.length > 0" >
         <button type="button" class="button blue small" (click)="clearGagestatsFilters()">
 			<i class="far fa-times"></i>
 			<span>Reset Filters</span>

--- a/src/app/gagestats/gs-sidebar/gs-sidebar.component.ts
+++ b/src/app/gagestats/gs-sidebar/gs-sidebar.component.ts
@@ -9,6 +9,7 @@ import { ConfigService } from 'app/config.service';
 import { Config } from 'protractor';
 import { Regressiontype } from 'app/shared/interfaces/regressiontype';
 import { Variabletype } from 'app/shared/interfaces/variabletype';
+import { Regulationstatus } from 'app/shared/interfaces/regulationstatus';
 import { Statisticgroup } from 'app/shared/interfaces/statisticgroup';
 import { HttpParams } from '@angular/common/http';
 
@@ -23,6 +24,7 @@ export class GsSidebarComponent implements OnInit {
   public regressionTypes: Array<Regressiontype>;
   public statisticGroups: Array<Statisticgroup>;
   public variableTypes: Array<Variabletype>;
+  public regulationStatuses: Array<Regulationstatus>;
   public regions: Array<Region>;
   public agencies: Array<Agency>;
   // Dropdown menu default text
@@ -35,6 +37,7 @@ export class GsSidebarComponent implements OnInit {
   public selectedStatisticGroups = [];
   public selectedRegressionTypes = [];
   public selectedVariableTypes = [];
+  public selectedRegulationStatuses = [];
   public keyword = "";
   public timeout: any = null;
   public loadCount = 0;
@@ -85,6 +88,10 @@ export class GsSidebarComponent implements OnInit {
     this._settingsservice.getEntities(this.configSettings.gageStatsBaseURL + this.configSettings.regTypeURL).subscribe((rt: Array<Regressiontype>) => {
       this.regressionTypes = rt;
     });
+    this.regulationStatuses = [
+      {id: true, name: "Regulated"},
+      {id: false, name: "Not Regulated"}
+    ];
 
     // trigger initial stations search
     this._nssService.searchStations(this.params);
@@ -116,7 +123,7 @@ export class GsSidebarComponent implements OnInit {
   public onSearch() {
     this.loadCount = this.loadCount + 1;
 
-    if (this.loadCount > 5) {  //resolves issue with mupltiple filter calls on load
+    if (this.loadCount > 6) {  //resolves issue with multiple filter calls on load
       //set up params
       this.params = this.params.set('page', '1');
       this.params = this.params.set('regions', this.selectedRegions.toString()); 
@@ -125,6 +132,7 @@ export class GsSidebarComponent implements OnInit {
       this.params = this.params.set('statisticgroups', this.selectedStatisticGroups.toString()); 
       this.params = this.params.set('regressiontypes', this.selectedRegressionTypes.toString()); 
       this.params = this.params.set('variableTypes', this.selectedVariableTypes.toString()); 
+      this.params = this.params.set('isRegulated', this.selectedRegulationStatuses.toString()); 
       this.params = this.params.set('filterText', this.keyword.toString()); 
 
       //regions
@@ -177,6 +185,7 @@ export class GsSidebarComponent implements OnInit {
     this.selectedAgencies = [];
     this.selectedStationTypes = []; 
     this.selectedVariableTypes = [];
+    this.selectedRegulationStatuses = [];
     this.selectedRegressionTypes = [];
     this.selectedStatisticGroups = [];
     this.keyword = "";

--- a/src/app/shared/interfaces/regulationstatus.ts
+++ b/src/app/shared/interfaces/regulationstatus.ts
@@ -1,0 +1,4 @@
+export interface Regulationstatus {
+    id: boolean;
+    name: string;
+}


### PR DESCRIPTION
Closes #417 

Adds a filter in the Gagestats sidebar to filter stations by regulation status.

We should wait to merge until test.streamstats.usgs.gov/gagestatsservices has been updated. If you want to test locally, change `gageStatsBaseURL` to `http://localhost:53812/` in config.json while running the dev branch of GageStatsServices locally.